### PR TITLE
Adding https detection so we can load resources over https

### DIFF
--- a/src/core/Tw2ResMan.js
+++ b/src/core/Tw2ResMan.js
@@ -117,7 +117,14 @@ Inherit(Tw2LoadingObject, Tw2Resource);
 function Tw2ResMan()
 {
     this.resourcePaths = {};
-    this.resourcePaths['res'] = 'http://developers.eveonline.com/ccpwgl/assetpath/860161/';
+    
+    if(window.location.protocol == "https:") {
+        this.resourcePaths['protocol'] = "https:";
+    } else {
+        this.resourcePaths['protocol'] = "http:";
+    }
+    
+    this.resourcePaths['res'] = this.resourcePaths['protocol'] + '//developers.eveonline.com/ccpwgl/assetpath/860161/';
     
     this._extensions = {};
     this.motherLode = new Tw2MotherLode();

--- a/src/core/Tw2ResMan.js
+++ b/src/core/Tw2ResMan.js
@@ -118,13 +118,14 @@ function Tw2ResMan()
 {
     this.resourcePaths = {};
     
+    this.resourcePaths['res'] = '//developers.eveonline.com/ccpwgl/assetpath/860161/';
     if(window.location.protocol == "https:") {
-        this.resourcePaths['protocol'] = "https:";
+        this.resourcePaths['res'] = 'https:' + this.resourcePaths['res'];
     } else {
-        this.resourcePaths['protocol'] = "http:";
+        this.resourcePaths['res'] = 'http:' + this.resourcePaths['res'];
     }
     
-    this.resourcePaths['res'] = this.resourcePaths['protocol'] + '//developers.eveonline.com/ccpwgl/assetpath/860161/';
+    
     
     this._extensions = {};
     this.motherLode = new Tw2MotherLode();


### PR DESCRIPTION
This is aimed at resolving issue #18 

There will still be an issue on the server side though. The developers.eveonline.com path redirects to CCP's cdn but does not carry with it the protocol, only directing to http. The cdn supports https but this behavior might be intentional.