### PR TITLE
Update EveSOF.js > SetupDecal Function

### DIFF
--- a/src/eve/EveSOF.js
+++ b/src/eve/EveSOF.js
@@ -158,6 +158,8 @@ function EveSOF() {
             decal.boneIndex = _get(hullDecal, 'boneIndex', -1);
             decal.indexBuffer = new Uint16Array(hullDecal.indexBuffer);
             decal.decalEffect = effect;
+            decal.name = hullDecals[i].name;
+            decal.groupIndex = hullDecals[i].groupIndex;
             decal.Initialize();
 
             ship.decals.push(decal);


### PR DESCRIPTION
Decal names will now be named as per hull SOF file rather than "".
The SOF groupIndex added for each decal object created. While not necessary for ccpwgl it makes it easier to create a custom SOF object from a loaded ccpwgl space object.