### PR TITLE
Updated EveSpaceObjectDecal / groupIndex

### DIFF
--- a/src/eve/EveSpaceObjectDecal.js
+++ b/src/eve/EveSpaceObjectDecal.js
@@ -3,6 +3,7 @@ function EveSpaceObjectDecal()
     this.display = true;
     this.decalEffect = null;
     this.name = '';
+    this.groupIndex = null;
     
     this.position = vec3.create();
     this.rotation = quat4.create();


### PR DESCRIPTION
Added this.groupIndex to reflect pull request for EveSOF.js.
While not necessary for ccpwgl having the original SOF groupIndex available per decal it makes it easier to create a custom SOF object from a loaded ccpwgl space object.