### PR TITLE
Added .GetValue prototype to Tw2Vector4Parameter

### DIFF
--- a/src/core/Tw2Vector4Parameter.js
+++ b/src/core/Tw2Vector4Parameter.js
@@ -58,3 +58,15 @@ Tw2Vector4Parameter.prototype.Apply = function (constantBuffer, offset, size)
 {
     constantBuffer.set(this.value, offset);
 };
+
+Tw2Vector4Parameter.prototype.GetValue = function()
+{
+    if (this.constantBuffer != null)
+    {
+    	return this.constantBuffer.subarray(this.offset, this.offset + this.value.length);
+    }
+    
+    return this.value;
+};
+
+


### PR DESCRIPTION
Added `.GetValue` prototype which returns the constant buffer value of the Tw2Vector4Parameter when `this.constantBuffer` exists (allowing for custom values rather than returning the original value) otherwise returns `this.value`.