### PR TITLE
Added .GetValue prototype to Tw2Vector3Parameter

### DIFF
--- a/src/core/Tw2Vector3Parameter.js
+++ b/src/core/Tw2Vector3Parameter.js
@@ -58,3 +58,13 @@ Tw2Vector3Parameter.prototype.Apply = function (constantBuffer, offset, size)
 {
     constantBuffer.set(this.value, offset);
 };
+
+Tw2Vector3Parameter.prototype.GetValue = function()
+{
+    if (this.constantBuffer != null)
+    {
+    	return this.constantBuffer.subarray(this.offset, this.offset + this.value.length);
+    }
+    
+    return this.value;
+};


### PR DESCRIPTION
Added `.GetValue` prototype which returns the constant buffer value of the Tw2Vector3Parameter when `this.constantBuffer` exists (allowing for custom values rather than returning the original value) otherwise returns `this.value`.