### PR TITLE
Added .GetData function to Tw2RawData

### DIFF
--- a/src/core/Tw2RawData.js
+++ b/src/core/Tw2RawData.js
@@ -30,3 +30,8 @@ Tw2RawData.prototype.Get = function (name)
 {
     return this.elements[name].array;
 };
+
+Tw2RawData.prototype.GetData = function (name) 
+{
+    return this.data.subarray(this.elements[name].offset, this.elements[name].offset + this.elements[name].array.length);
+},


### PR DESCRIPTION
`Tw2RawData.prototype.GetData(name)` returns the current values for a RawData element from the data array.
As this prototype returns a reference, it has a slightly different purpose/ functionality to `Tw2RawData.prototype.Get` which returns the element's (original) properties.