### PR TITLE
Updated Tw2FloatParameter with GetValue prototype

### DIFF
--- a/src/core/Tw2FloatParameter.js
+++ b/src/core/Tw2FloatParameter.js
@@ -48,3 +48,13 @@ Tw2FloatParameter.prototype.Apply = function (constantBuffer, offset, size)
 {
     constantBuffer[offset] = this.value;
 };
+
+Tw2FloatParameter.prototype.GetValue = function()
+{
+    if (this.constantBuffer != null)
+    {
+    	return this.constantBuffer[this.offset];
+    }
+    
+    return this.value;
+};


### PR DESCRIPTION
Updated Tw2FloatParameter with GetValue prototype which returns the current parameter value from it's constant buffer (if it is not null), otherwise returns the current value.