### PR TITLE
Create RenderAndSpinWhenEverythingHasLoaded.html

### DIFF
--- a/demos/RenderAndSpinWhenEverythingHasLoaded.html
+++ b/demos/RenderAndSpinWhenEverythingHasLoaded.html
@@ -1,0 +1,154 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+        "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html>
+<head>
+    <title>WebGL API Test - Render and spin when everything has loaded</title>
+
+    <script type="text/javascript" src="../core/src/external/glMatrix-0.9.5.min.js"></script>
+    <script type="text/javascript" src="../core/src/ccpwgl/ccpwgl_int.js"></script>
+    <script type="text/javascript" src="../core/src/ccpwgl/TestCamera2.js"></script>
+    <script type="text/javascript" src="../core/src/ccpwgl/ccpwgl.js"></script>
+
+    <script type="text/javascript">
+        // Variable declared globally so you can do testing in your javascript console
+        var ship = [];
+
+        function onDocumentLoad()
+        {
+            var canvas = document.getElementById('mainCanvas');
+            ccpwgl.initialize(canvas, {postProcessing: true});
+            var scene = ccpwgl.loadScene('res:/dx9/scene/universe/a01_cube.red');
+            
+            var camera = new TestCamera(canvas);
+            camera.minDistance = 10;
+            camera.maxDistance = 10000;
+            camera.fov = 30;
+            camera.distance = 5000;
+            camera.nearPlane = 1;
+            camera.farPlane = 10000000;
+            camera.minPitch = -0.5;
+            camera.maxPitch = 0.65;
+            ccpwgl.setCamera(camera);
+
+            // Variable to hold project load states
+            var hasProjectLoaded = false;
+            var hasNebulaLoaded = false;
+            
+            // Turn Scene Rendering and Updating off so the user doesn't see the scene and ships loading
+            ccpwgl.enableRendering(false);
+            ccpwgl.enableUpdate(false);
+
+            /**
+             * Returns a boolean value based on whether the scene and any other resources are still loading
+             * @return {boolean}
+             */
+            function areLoadsPending()
+            {
+                return (!scene || ccpwgl_int.resMan._pendingLoads > 0)
+            }
+
+            /**
+             *  Creates a new transform from an identity matrix and supplied arguments
+             *  @param (rotation) vec3 array - Rotation in space [x,y,z]
+             *  @param (position) vec3 array - Position in space [x,y,z]
+             *  @param (scale) vec3 array - Scale [x,y,z]
+             *  @returns {mat4} Transform matrix
+             */
+            function createTransform(rotation, position, scale)
+            {
+                var transform = mat4.identity(mat4.create());
+                mat4.translate(transform, position);
+                mat4.rotate(transform, rotation[0] * ( Math.PI / 180 ), [1, 0, 0]);
+                mat4.rotate(transform, rotation[1] * ( Math.PI / 180 ), [0, 1, 0]);
+                mat4.rotate(transform, rotation[2] * ( Math.PI / 180 ), [0, 0, 1]);
+                mat4.scale(transform, scale);
+                return transform;
+            }
+
+            // Load all of the tech 3 destroyers
+            ship[0] = scene.loadShip('ade3_t3:amarrbase:amarr', whenLoaded);
+            ship[1] = scene.loadShip('cde3_t3:caldaribase:caldari', whenLoaded);
+            ship[2] = scene.loadShip('gde3_t3:gallentebase:gallente', whenLoaded);
+            ship[3] = scene.loadShip('mde3_t3:minmatarbase:minmatar', whenLoaded);
+
+            // A callback function that is run once the ship's base javascript object has loaded.
+            // Points to the ship instance
+            function whenLoaded()
+            {
+                var rotation = vec3.create([0, 0, 0]);
+                var position = vec3.create([0, 0, 0]);
+                var scale = vec3.create([1, 1, 1]);
+
+                // Each ship gets it's own auto rotation values
+                this.autoRotate = vec3.create([0, 1, 0]);
+                this.doAutoRotate = true;
+
+                // Re-Position the ship
+                position = [600 * ship.indexOf(this) - 900, 0, 0];
+
+                // Turn boosters off
+                this.setBoosterStrength(0);
+
+                // Rotation
+                Object.defineProperty(this, 'rotation', {
+                    get: function ()
+                    {
+                        return rotation;
+                    },
+                    set: function (vec3)
+                    {
+                        try
+                        {
+                            var newTransform = createTransform(vec3, position, scale);
+                            this.setTransform(newTransform)
+                        }
+                        catch (err)
+                        {
+                            throw('Transform Error');
+                        }
+                        rotation = vec3;
+                    }
+                });
+
+                /**
+                 * Creates an internal method which is run per frame
+                 * @param (dt) {number} dt Frame Time
+                 */
+                this.onUpdate = function (dt)
+                {
+                    // If the ship's `doAutoRotate` value is true and the project has completely loaded,
+                    // rotate the ship's axis by the relevant `autoRotate` values
+                    if (this.doAutoRotate && hasProjectLoaded)
+                    {
+                        rotation[0] = rotation[0] + this.autoRotate[0] / 10;
+                        rotation[1] = rotation[1] + this.autoRotate[1] / 10;
+                        rotation[2] = rotation[2] + this.autoRotate[2] / 10;
+                        this.rotation = rotation;
+                    }
+                }
+            }
+
+            /**
+             * Internal ccpwgl function which is run per frame
+             * @param (dt) {number} dt Frame Time
+             */
+            ccpwgl.onPostRender = function (dt)
+            {
+                // Turn Rendering and Updates back on once the scene has completely loaded
+                if (!hasProjectLoaded && !areLoadsPending())
+                {
+                    hasProjectLoaded = true;
+                    ccpwgl.enableRendering(true);
+                    ccpwgl.enableUpdate(true);
+                }
+            }
+
+        }
+        onload = onDocumentLoad;
+    </script>
+
+</head>
+<body style="margin:0">
+<canvas id="mainCanvas" style="position:fixed;width:100%;height:100%"></canvas>
+</body>
+</html>

--- a/demos/RenderAndSpinWhenEverythingHasLoaded.html
+++ b/demos/RenderAndSpinWhenEverythingHasLoaded.html
@@ -4,10 +4,10 @@
 <head>
     <title>WebGL API Test - Render and spin when everything has loaded</title>
 
-    <script type="text/javascript" src="../core/src/external/glMatrix-0.9.5.min.js"></script>
-    <script type="text/javascript" src="../core/src/ccpwgl/ccpwgl_int.js"></script>
-    <script type="text/javascript" src="../core/src/ccpwgl/TestCamera2.js"></script>
-    <script type="text/javascript" src="../core/src/ccpwgl/ccpwgl.js"></script>
+    <script type="text/javascript" src="../src/external/glMatrix-0.9.5.min.js"></script>
+    <script type="text/javascript" src="../src/ccpwgl_int.js"></script>
+    <script type="text/javascript" src="../src/test/TestCamera2.js"></script>
+    <script type="text/javascript" src="../src/ccpwgl.js"></script>
 
     <script type="text/javascript">
         // Variable declared globally so you can do testing in your javascript console


### PR DESCRIPTION
Demonstrates:
> Identifying when all resources have loaded (More precise than .isLoaded methods)
> Disabling rendering and updating until everything has loaded
> Automatic Ship Spinning when everything has loaded
> Custom onUpdate() Methods