### PR TITLE
Added .FillWith() Prototype

### DIFF
--- a/src/core/Tw2Vector4Parameter.js
+++ b/src/core/Tw2Vector4Parameter.js
@@ -99,4 +99,13 @@ Tw2Vector4Parameter.prototype.SetIndexValue = function(index, value)
     }
 };
 
-
+Tw2Vector2Parameter.prototype.FillWith = function(number)
+{
+    if (/^-?[\d.]+(?:e-?\d+)?$/.test(number))
+    {
+	this.SetValue([number, number, number, number]);
+	return;
+    }
+    
+    throw "Expected Number"
+};


### PR DESCRIPTION
Sets all `this.value` array elements to the supplied number.

_Example Usage:_
```
// Clear a Ship's Material 1 Fresnsel Colour by setting all values to 0
ship.wrappedObjects[0].mesh.opaqueAreas[0].effect.parameters.Mtl1FresnelColor.FillWith(0);
```