### PR TITLE
Added FillWith prototype to all Tw2 Parameters and added SetValue method to Tw2FloatParameter

### DIFF
--- a/src/core/Tw2FloatParameter.js
+++ b/src/core/Tw2FloatParameter.js
@@ -58,3 +58,15 @@ Tw2FloatParameter.prototype.GetValue = function()
     
     return this.value;
 };
+
+Tw2FloatParameter.prototype.FillWith = function(number)
+{
+    if (/^-?[\d.]+(?:e-?\d+)?$/.test(number))
+    {
+        this.SetValue(number);
+        return;
+    }
+
+    throw "Expected Number"
+};
+

--- a/src/core/Tw2FloatParameter.js
+++ b/src/core/Tw2FloatParameter.js
@@ -59,6 +59,11 @@ Tw2FloatParameter.prototype.GetValue = function()
     return this.value;
 };
 
+Tw2FloatParameter.prototype.SetValue = function (value)
+{
+    this.value = value;
+};
+
 Tw2FloatParameter.prototype.FillWith = function(number)
 {
     if (/^-?[\d.]+(?:e-?\d+)?$/.test(number))

--- a/src/core/Tw2Vector2Parameter.js
+++ b/src/core/Tw2Vector2Parameter.js
@@ -97,3 +97,15 @@ Tw2Vector2Parameter.prototype.SetIndexValue = function(index, value)
     }
 };
 
+Tw2Vector2Parameter.prototype.FillWith = function(number)
+{
+    if (/^-?[\d.]+(?:e-?\d+)?$/.test(number))
+    {
+        this.SetValue(number, number);
+        return;
+    }
+
+    throw "Expected Number"
+};
+
+

--- a/src/core/Tw2Vector3Parameter.js
+++ b/src/core/Tw2Vector3Parameter.js
@@ -98,3 +98,14 @@ Tw2Vector3Parameter.prototype.SetIndexValue = function(index, value)
         this.constantBuffer[this.offset + index] = value;
     }
 };
+
+Tw2Vector3Parameter.prototype.FillWith = function(number)
+{
+    if (/^-?[\d.]+(?:e-?\d+)?$/.test(number))
+    {
+        this.SetValue(number, number, number);
+        return;
+    }
+
+    throw "Expected Number"
+};

--- a/src/core/Tw2Vector4Parameter.js
+++ b/src/core/Tw2Vector4Parameter.js
@@ -99,4 +99,14 @@ Tw2Vector4Parameter.prototype.SetIndexValue = function(index, value)
     }
 };
 
+Tw2Vector4Parameter.prototype.FillWith = function(number)
+{
+    if (/^-?[\d.]+(?:e-?\d+)?$/.test(number))
+    {
+        this.SetValue(number, number, number, number);
+        return;
+    }
+
+    throw "Expected Number"
+};
 


### PR DESCRIPTION
Added `.FillWith(value)` prototype to all Tw2VectorParameters and Tw2FloatParameter
Added `.SetValue(value)` prototype to Tw2FloatParameter to match other Tw2Parameters

`.FillWith(value)` prototype fills a Tw2 Vector or Float Parameter with the supplied value in each of it's `this.value` array elements, or in the case of a Float, sets it's `this.value` to the supplied value.
This prototype is useful when resetting parameter options to defaults/ or nothing without having to identify the parameter type. An example:  parameters are applied to a Tw2Effect, any of the Tw2Effects parameters that weren't changed are filled with '0's.
Added to Tw2FloatParameter for consistancy.