### PR TITLE
Tw2 Parameters .FillWith() Prototype, Tw2FloatParameter .SetValue(), Hull Sets groupName

### DIFF
--- a/src/core/Tw2FloatParameter.js
+++ b/src/core/Tw2FloatParameter.js
@@ -58,3 +58,15 @@ Tw2FloatParameter.prototype.GetValue = function()
     
     return this.value;
 };
+
+Tw2FloatParameter.prototype.FillWith = function(number)
+{
+    if (/^-?[\d.]+(?:e-?\d+)?$/.test(number))
+    {
+        this.SetValue(number);
+        return;
+    }
+
+    throw "Expected Number"
+};
+

--- a/src/core/Tw2FloatParameter.js
+++ b/src/core/Tw2FloatParameter.js
@@ -61,7 +61,7 @@ Tw2FloatParameter.prototype.GetValue = function()
 
 Tw2FloatParameter.prototype.FillWith = function(number)
 {
-    if (/^-?[\d.]+(?:e-?\d+)?$/.test(number))
+    if (number != null && isFinite(number))
     {
         this.SetValue(number);
         return;

--- a/src/core/Tw2FloatParameter.js
+++ b/src/core/Tw2FloatParameter.js
@@ -36,6 +36,11 @@ Tw2FloatParameter.prototype.Unbind = function ()
     this.constantBuffer = null;
 };
 
+Tw2FloatParameter.prototype.SetValue = function (value)
+{
+    this.value = value;
+};
+
 Tw2FloatParameter.prototype.OnValueChanged = function ()
 {
     if (this.constantBuffer != null)

--- a/src/core/Tw2Vector2Parameter.js
+++ b/src/core/Tw2Vector2Parameter.js
@@ -99,7 +99,7 @@ Tw2Vector2Parameter.prototype.SetIndexValue = function(index, value)
 
 Tw2Vector2Parameter.prototype.FillWith = function(number)
 {
-    if (/^-?[\d.]+(?:e-?\d+)?$/.test(number))
+    if (number != null && isFinite(number))
     {
         this.SetValue(number, number);
         return;

--- a/src/core/Tw2Vector2Parameter.js
+++ b/src/core/Tw2Vector2Parameter.js
@@ -97,3 +97,15 @@ Tw2Vector2Parameter.prototype.SetIndexValue = function(index, value)
     }
 };
 
+Tw2Vector2Parameter.prototype.FillWith = function(number)
+{
+    if (/^-?[\d.]+(?:e-?\d+)?$/.test(number))
+    {
+        this.SetValue(number, number);
+        return;
+    }
+
+    throw "Expected Number"
+};
+
+

--- a/src/core/Tw2Vector3Parameter.js
+++ b/src/core/Tw2Vector3Parameter.js
@@ -98,3 +98,14 @@ Tw2Vector3Parameter.prototype.SetIndexValue = function(index, value)
         this.constantBuffer[this.offset + index] = value;
     }
 };
+
+Tw2Vector3Parameter.prototype.FillWith = function(number)
+{
+    if (/^-?[\d.]+(?:e-?\d+)?$/.test(number))
+    {
+        this.SetValue(number, number, number);
+        return;
+    }
+
+    throw "Expected Number"
+};

--- a/src/core/Tw2Vector3Parameter.js
+++ b/src/core/Tw2Vector3Parameter.js
@@ -101,7 +101,7 @@ Tw2Vector3Parameter.prototype.SetIndexValue = function(index, value)
 
 Tw2Vector3Parameter.prototype.FillWith = function(number)
 {
-    if (/^-?[\d.]+(?:e-?\d+)?$/.test(number))
+    if (number != null && isFinite(number))
     {
         this.SetValue(number, number, number);
         return;

--- a/src/core/Tw2Vector4Parameter.js
+++ b/src/core/Tw2Vector4Parameter.js
@@ -99,4 +99,14 @@ Tw2Vector4Parameter.prototype.SetIndexValue = function(index, value)
     }
 };
 
+Tw2Vector4Parameter.prototype.FillWith = function(number)
+{
+    if (/^-?[\d.]+(?:e-?\d+)?$/.test(number))
+    {
+        this.SetValue(number, number, number, number);
+        return;
+    }
+
+    throw "Expected Number"
+};
 

--- a/src/core/Tw2Vector4Parameter.js
+++ b/src/core/Tw2Vector4Parameter.js
@@ -101,7 +101,7 @@ Tw2Vector4Parameter.prototype.SetIndexValue = function(index, value)
 
 Tw2Vector4Parameter.prototype.FillWith = function(number)
 {
-    if (/^-?[\d.]+(?:e-?\d+)?$/.test(number))
+    if (number != null && isFinite(number))
     {
         this.SetValue(number, number, number, number);
         return;

--- a/src/eve/EveSOF.js
+++ b/src/eve/EveSOF.js
@@ -186,6 +186,7 @@ function EveSOF() {
                 if ('color' in factionSet) {
                     item.color = factionSet.color;
                 }
+
                 item.blinkPhase = _get(hullData[j], 'blinkPhase', 0);
                 item.blinkRate = _get(hullData[j], 'blinkRate', 0.1);
                 item.boneIndex = _get(hullData[j], 'boneIndex', 0);
@@ -196,7 +197,7 @@ function EveSOF() {
                 if ('groupIndex' in hullData[j]) {
                     item.groupIndex = hullData[j].groupIndex; 
                 }
-                item.groupName = factionSet.name;
+                item.groupName = _get(factionSet, 'name', '');
                 if ('position' in hullData[j]) {
                     item.position = hullData[j].position;
                 }
@@ -256,6 +257,7 @@ function EveSOF() {
                     quat4.set([1, 1, 1, 1], item.flareColor);
                     quat4.set([1, 1, 1, 1], item.spriteColor);
                 }
+                item.groupName = _get(factionSet, 'name', '');
                 item.spriteScale = _get(hullData[j], 'spriteScale', [1, 1, 1]);
                 if ('transform' in hullData[j]) {
                     item.transform = hullData[j].transform;
@@ -314,6 +316,7 @@ function EveSOF() {
                 if (factionSet) {
                     quat4.set(_get(factionSet, 'color', [0, 0, 0, 0]), item.color);
                 }
+                item.groupName = _get(factionSet, 'name', '');
                 planeSet.planes.push(item);
             }
             planeSet.Initialize();

--- a/src/eve/EveSOF.js
+++ b/src/eve/EveSOF.js
@@ -257,7 +257,7 @@ function EveSOF() {
                     quat4.set([1, 1, 1, 1], item.flareColor);
                     quat4.set([1, 1, 1, 1], item.spriteColor);
                 }
-                item.groupName = _get(factionSet, 'name', '');
+                item.groupName = (factionSet) ? _get(factionSet, 'name', '') : '';
                 item.spriteScale = _get(hullData[j], 'spriteScale', [1, 1, 1]);
                 if ('transform' in hullData[j]) {
                     item.transform = hullData[j].transform;
@@ -316,7 +316,7 @@ function EveSOF() {
                 if (factionSet) {
                     quat4.set(_get(factionSet, 'color', [0, 0, 0, 0]), item.color);
                 }
-                item.groupName = _get(factionSet, 'name', '');
+                item.groupName = (factionSet) ? _get(factionSet, 'name', '') : '';
                 planeSet.planes.push(item);
             }
             planeSet.Initialize();


### PR DESCRIPTION
Added `.FillWith(value)` prototype to all Tw2VectorParameters and Tw2FloatParameter
Added `.SetValue(value)` prototype to Tw2FloatParameter to match other Tw2Parameters
Added `groupName` key/ value to PlaneSet Items and SpotlightSet items to bring them inline with SpriteSet Items.

`.FillWith(value)` prototype fills a Tw2 Vector or Float Parameter with the supplied value in each of it's `this.value` array elements, or in the case of a Float, sets it's `this.value` to the supplied value.
This prototype is useful when resetting parameter options to defaults/ or nothing without having to identify the parameter type. An example: parameters are applied to a Tw2Effect, any of the Tw2Effects parameters that weren't changed are filled with '0's. Added to Tw2FloatParameter for consistancy.

Made adjustments to the .FillWith() prototypes so that they were more readable.
Drove Fillip insane with pull requests and deletions - Sorry, having some issues with Git today :3