### PR TITLE
Added Tw2ParticleSystem Properties

### DIFF
--- a/src/particle/Tw2ParticleSystem.js
+++ b/src/particle/Tw2ParticleSystem.js
@@ -91,9 +91,9 @@ function Tw2ParticleSystem()
     
     this._stdElements = [ null, null, null, null ];
     this._elements = [];
-    //this.instanceStride = [ null, null ];
-    //this.vertexStride = [ null, null ];
-    //this.buffers = [ null, null ];
+    this.instanceStride = [ null, null ];
+    this.vertexStride = [ null, null ];
+    this.buffers = [ null, null ];
 }
 
 Tw2ParticleSystem.prototype.Initialize = function ()

--- a/src/particle/Tw2ParticleSystem.js
+++ b/src/particle/Tw2ParticleSystem.js
@@ -88,6 +88,12 @@ function Tw2ParticleSystem()
 
     this._vb = null;
     this._declaration = null;
+    
+    this._stdElements = [ null, null, null, null ];
+    this._elements = [];
+    //this.instanceStride = [ null, null ];
+    //this.vertexStride = [ null, null ];
+    //this.buffers = [ null, null ];
 }
 
 Tw2ParticleSystem.prototype.Initialize = function ()


### PR DESCRIPTION
Added `_stdElements` &  `_elements` properties to the Tw2ParticleSystem constructor
These properties are defined later by prototypes, but the properties can be requested before they are created (ie. .HasElement)
`intanceStride`, `vertexStride` and `buffers` are also defined in prototypes and perhaps should be defined in the constructor too.