### PR TITLE
Update Tw2ParticleSystem Constructor

### DIFF
--- a/src/particle/Tw2ParticleSystem.js
+++ b/src/particle/Tw2ParticleSystem.js
@@ -17,10 +17,10 @@ Tw2ParticleElementDeclaration.prototype.GetDimension = function ()
 {
     switch (this.elementType)
     {
-    case Tw2ParticleElementDeclaration.LIFETIME: return 2;
-    case Tw2ParticleElementDeclaration.POSITION: return 3;
-    case Tw2ParticleElementDeclaration.VELOCITY: return 3;
-    case Tw2ParticleElementDeclaration.MASS: return 1;
+        case Tw2ParticleElementDeclaration.LIFETIME: return 2;
+        case Tw2ParticleElementDeclaration.POSITION: return 3;
+        case Tw2ParticleElementDeclaration.VELOCITY: return 3;
+        case Tw2ParticleElementDeclaration.MASS: return 1;
     }
     return this.dimension;
 };
@@ -88,6 +88,12 @@ function Tw2ParticleSystem()
 
     this._vb = null;
     this._declaration = null;
+
+    this._stdElements = [ null, null, null, null ];
+    this._elements = [];
+    this.instanceStride = [ null, null ];
+    this.vertexStride = [ null, null ];
+    this.buffers = [ null, null ];
 }
 
 Tw2ParticleSystem.prototype.Initialize = function ()


### PR DESCRIPTION
Added properties to the Tw2ParticleSystem construtor that were defined only in it's prototypes which could cause some errors when other prototypes were called that expected them to be defined already  (HasElement). Added commented out properties as per Filipp's request.

  ```
    this._stdElements = [ null, null, null, null ];
    this._elements = [];
    this.instanceStride = [ null, null ];
    this.vertexStride = [ null, null ];
    this.buffers = [ null, null ];
```