### PR TITLE
Fixes to Tw2BatchAccumulator and Basic Documentation

### DIFF
--- a/src/core/Tw2BatchAccumulator.js
+++ b/src/core/Tw2BatchAccumulator.js
@@ -1,21 +1,45 @@
+/**
+ * Accumulates render batches for rendering
+ * @param {function} [sorting] - An optional function for sorting the collected render batches
+ * @property {Array.<RenderBatch>} batches
+ * @property {number} count - How many batch array elements will be processed
+ * @property {function} _sortMethod - the stored sorting function
+ * @constructor
+ */
 function Tw2BatchAccumulator(sorting)
 {
     this.batches = [];
     this.count = 0;
-    this._sortMethod = sorting;
+    this._sortMethod = (sorting) ? sorting : undefined;
 }
 
-Tw2BatchAccumulator.prototype.Commit = function (batch)
+/**
+ * Commits a batch to accumulation
+ * @param {RenderBatch} batch
+ * @prototype
+ */
+Tw2BatchAccumulator.prototype.Commit = function(batch)
 {
     this.batches[this.count++] = batch;
 };
 
-Tw2BatchAccumulator.prototype.Clear = function ()
+/**
+ * Clears any accumulated render batches
+ * @prototype
+ */
+Tw2BatchAccumulator.prototype.Clear = function()
 {
     this.count = 0;
+    this.batches = [];
 };
 
-Tw2BatchAccumulator.prototype.Render = function (overrideEffect)
+/**
+ * Renders the accumulated render batches
+ * - If a sorting function has been defined the render batches will be sorted before rendering
+ * @param {Tw2Effect} [overrideEffect]
+ * @prototype
+ */
+Tw2BatchAccumulator.prototype.Render = function(overrideEffect)
 {
     if (typeof(this._sortMethod) != 'undefined')
     {
@@ -32,18 +56,37 @@ Tw2BatchAccumulator.prototype.Render = function (overrideEffect)
     }
 };
 
+
+/**
+ * A standard render batch
+ * @property {RenderMode} renderMode
+ * @property {Tw2PerObjectData} perObjectData
+ * @constructor
+ */
 function Tw2RenderBatch()
 {
     this.renderMode = device.RM_ANY;
     this.perObjectData = null;
 }
 
+
+/**
+ * A render batch that uses geometry provided from an external source
+ * @property {GeometryProvider} geometryProvider
+ * @inherits Tw2RenderBatch
+ * @constructor
+ */
 function Tw2ForwardingRenderBatch()
 {
     this.geometryProvider = null;
 }
 
-Tw2ForwardingRenderBatch.prototype.Commit = function (overrideEffect)
+/**
+ * Commits the batch for rendering
+ * @param {Tw2Effect} [overrideEffect]
+ * @prototype
+ */
+Tw2ForwardingRenderBatch.prototype.Commit = function(overrideEffect)
 {
     if (this.geometryProvider)
     {


### PR DESCRIPTION
- Added Basic Documentation.
- Fixed an issue with the `_sortMethod` @property on in the Tw2BatchAccumulator constructor which caused Firefox, IE and Edge to throw when it was null (Chrome did not throw)
- Added `this.batches = []` to the Tw2BatchAccumulator Clear prototype.