### PR TITLE
Fixes to Tw2FloatParameter and Basic Documentation

### DIFF
--- a/src/core/Tw2FloatParameter.js
+++ b/src/core/Tw2FloatParameter.js
@@ -1,26 +1,45 @@
+/**
+ * Tw2FloatParameter
+ * @param {string} [name='']
+ * @param {number} [value=1]
+ * @property {string} name
+ * @property {number} value
+ * @property {null|Array} constantBuffer
+ * @property {null|number} offset
+ * @constructor
+ */
 function Tw2FloatParameter(name, value)
 {
-	if (typeof(name) != 'undefined')
-	{
-		this.name = name;
-	}
-	else
-	{
-		this.name = '';
-	}
-	if (typeof(value) != 'undefined')
-	{
-		this.value = value;
-	}
-	else
-	{
-		this.value = 1;
+    if (typeof(name) != 'undefined')
+    {
+        this.name = name;
+    }
+    else
+    {
+        this.name = '';
+    }
+    if (typeof(value) != 'undefined')
+    {
+        this.value = value;
+    }
+    else
+    {
+        this.value = 1;
     }
     this.constantBuffer = null;
+    this.offset = null;
 }
 
-
-Tw2FloatParameter.prototype.Bind = function (constantBuffer, offset, size)
+/**
+ * Bind
+ * TODO: Idenfify if @param size should be passed to the `Apply` prototype as it is currently redundant
+ * @param {Array} constantBuffer
+ * @param {number} offset
+ * @param {number} size
+ * @returns {boolean}
+ * @prototype
+ */
+Tw2FloatParameter.prototype.Bind = function(constantBuffer, offset, size)
 {
     if (this.constantBuffer != null || size < 1)
     {
@@ -31,12 +50,20 @@ Tw2FloatParameter.prototype.Bind = function (constantBuffer, offset, size)
     this.Apply(this.constantBuffer, this.offset, size);
 };
 
-Tw2FloatParameter.prototype.Unbind = function () 
+/**
+ * Unbind
+ * @prototype
+ */
+Tw2FloatParameter.prototype.Unbind = function()
 {
     this.constantBuffer = null;
 };
 
-Tw2FloatParameter.prototype.OnValueChanged = function ()
+/**
+ * Updates the constant buffer to the current value
+ * @prototype
+ */
+Tw2FloatParameter.prototype.OnValueChanged = function()
 {
     if (this.constantBuffer != null)
     {
@@ -44,17 +71,38 @@ Tw2FloatParameter.prototype.OnValueChanged = function ()
     }
 };
 
-Tw2FloatParameter.prototype.Apply = function (constantBuffer, offset, size)
+/**
+ * Applies the current value to the supplied constant buffer at the supplied offset
+ * TODO: @param size is currently redundant
+ * @param {Array} constantBuffer
+ * @param {number} offset
+ * @param {number} size
+ * @prototype
+ */
+Tw2FloatParameter.prototype.Apply = function(constantBuffer, offset, size)
 {
     constantBuffer[offset] = this.value;
 };
 
+/**
+ * Gets the current value
+ * @prototype
+ */
 Tw2FloatParameter.prototype.GetValue = function()
 {
     if (this.constantBuffer != null)
     {
-    	return this.constantBuffer[this.offset];
+        return this.constantBuffer[this.offset];
     }
-    
+
     return this.value;
+};
+
+/**
+ * Sets a supplied value
+ * @prototype
+ */
+Tw2FloatParameter.prototype.SetValue = function(value)
+{
+    this.value = value;
 };


### PR DESCRIPTION
- Basic Documentation
- Added `this.offset` @property which was missing from the Tw2FloatParameter Constructor
- Added 'SetValue' prototype to bring it inline with other Tw2 parameters

The `size` @param in the `Apply` prototype is currently redundant.
- It is also passed to the `Apply` prototype from within the `Bind` prototype
- This is also true for the other tw2 parameters 

Perhaps the `Apply` prototype for all Tw2 Parameters could be changed to:
```
Tw2FloatParameter.prototype.Apply = function(constantBuffer, offset, size)
{
    constantBuffer.set(this.value, offset, size)
}
```