### PR TITLE
Basic Documentation Tw2PerObjectData

### DIFF
--- a/src/core/Tw2PerObjectData.js
+++ b/src/core/Tw2PerObjectData.js
@@ -1,8 +1,17 @@
+/**
+ * Tw2PerObjectData
+ * TODO: Identify if @property perObjectVSData and @property perObjectPSData should be defined here
+ * @constructor
+ */
 function Tw2PerObjectData()
-{
-}
+{}
 
-Tw2PerObjectData.prototype.SetPerObjectDataToDevice = function (constantBufferHandles)
+/**
+ * SetPerObjectDataToDevice
+ * @param constantBufferHandles
+ * @constructor
+ */
+Tw2PerObjectData.prototype.SetPerObjectDataToDevice = function(constantBufferHandles)
 {
     if (this.perObjectVSData && constantBufferHandles[3])
     {


### PR DESCRIPTION
- Basic Documentation
- Note: @property `perObjectVSData` and @property `perObjectPSData` are not defined in the `Tw2PerObjectData` constructor