### PR TITLE
New Prototype, Fix and Basic Documentation Tw2Vector2Parameter

### DIFF
--- a/src/core/Tw2Vector2Parameter.js
+++ b/src/core/Tw2Vector2Parameter.js
@@ -1,24 +1,45 @@
+/**
+ * Tw2Vector2Parameter
+ * @param {string} [name='']
+ * @param {Vector2} [value=[1,1]]
+ * @property {string} name
+ * @property {Vector2} value
+ * @property {Array} constantBuffer
+ * @property {number} offset
+ * @constructor
+ */
 function Tw2Vector2Parameter(name, value)
 {
-	if (typeof(name) != 'undefined')
-	{
-		this.name = name;
-	}
-	else
-	{
-		this.name = '';
-	}
-	if (typeof(value) != 'undefined')
-	{
-		this.value = value;
-	}
-	else
-	{
-		this.value = new Float32Array([1, 1]);
-	}
+    if (typeof(name) != 'undefined')
+    {
+        this.name = name;
+    }
+    else
+    {
+        this.name = '';
+    }
+    if (typeof(value) != 'undefined')
+    {
+        this.value = value;
+    }
+    else
+    {
+        this.value = new Float32Array([1, 1]);
+    }
+    this.constantBuffer = null;
+    this.offset = 0;
 }
 
-Tw2Vector2Parameter.prototype.Bind = function (constantBuffer, offset, size)
+/**
+ * Bind
+ * TODO: Identify if @param size should be passed to the `Apply` prototype as it is currently redundant
+ * @param {Array} constantBuffer
+ * @param {number} offset
+ * @param {number} size
+ * @returns {boolean}
+ * @prototype
+ */
+Tw2Vector2Parameter.prototype.Bind = function(constantBuffer, offset, size)
 {
     if (this.constantBuffer != null || size < 2)
     {
@@ -30,12 +51,21 @@ Tw2Vector2Parameter.prototype.Bind = function (constantBuffer, offset, size)
     return true;
 };
 
-Tw2Vector2Parameter.prototype.Unbind = function ()
+/**
+ * Unbind
+ * @prototype
+ */
+Tw2Vector2Parameter.prototype.Unbind = function()
 {
     this.constantBuffer = null;
 };
 
-Tw2Vector2Parameter.prototype.SetValue = function (value)
+/**
+ * Sets a supplied value
+ * @param {Array} value - Vector2 Array
+ * @prototype
+ */
+Tw2Vector2Parameter.prototype.SetValue = function(value)
 {
     this.value = value;
     if (this.constantBuffer != null)
@@ -44,7 +74,11 @@ Tw2Vector2Parameter.prototype.SetValue = function (value)
     }
 };
 
-Tw2Vector2Parameter.prototype.OnValueChanged = function ()
+/**
+ * Updates the constant buffer to the current value
+ * @prototype
+ */
+Tw2Vector2Parameter.prototype.OnValueChanged = function()
 {
     if (this.constantBuffer != null)
     {
@@ -52,48 +86,84 @@ Tw2Vector2Parameter.prototype.OnValueChanged = function ()
     }
 };
 
-Tw2Vector2Parameter.prototype.Apply = function (constantBuffer, offset, size)
+/**
+ * Applies the current value to the supplied constant buffer at the supplied offset
+ * TODO: @param size is currently redundant
+ * @param {Array} constantBuffer
+ * @param {number} offset
+ * @param {number} size
+ * @prototype
+ */
+Tw2Vector2Parameter.prototype.Apply = function(constantBuffer, offset, size)
 {
     constantBuffer.set(this.value, offset);
 };
 
+/**
+ * Gets the current value array
+ * @return {Array} Vector2 Array
+ * @prototype
+ */
 Tw2Vector2Parameter.prototype.GetValue = function()
 {
     if (this.constantBuffer != null)
     {
-    	return this.constantBuffer.subarray(this.offset, this.offset + this.value.length);
+        return Array.from(this.constantBuffer.subarray(this.offset, this.offset + this.value.length));
     }
-    
-    return this.value;
+
+    return Array.from(this.value);
 };
 
+/**
+ * Returns a value from a specific index of the value array
+ * @param {number} index
+ * @returns {number}
+ * @throw Invalid Index
+ * @prototype
+ */
 Tw2Vector2Parameter.prototype.GetIndexValue = function(index)
 {
     if (typeof this.value[index] === 'undefined')
     {
         throw "Invalid Index";
     }
-    
+
     if (this.constantBuffer != null)
     {
-    	return this.constantBuffer[this.offset + index];
+        return this.constantBuffer[this.offset + index];
     }
-    
+
     return this.value[index];
 };
 
+/**
+ * Sets a value at a specific index of the value array
+ * @param {number} index
+ * @param {number} value
+ * @throw Invalid Index
+ * @prototype
+ */
 Tw2Vector2Parameter.prototype.SetIndexValue = function(index, value)
 {
     if (typeof this.value[index] === 'undefined')
     {
         throw "Invalid Index";
     }
-    
+
     this.value[index] = value;
-    
+
     if (this.constantBuffer != null)
     {
         this.constantBuffer[this.offset + index] = value;
     }
 };
 
+/**
+ * Sets all value array elements to a single value
+ * @param {number} value - The value to fill the value array elements with
+ * @prototype
+ */
+Tw2Vector2Parameter.prototype.FillWith = function(value)
+{
+    this.SetValue([value, value]);
+};


### PR DESCRIPTION
- Basic Documentation
- Fixed `GetValue` prototype. Changes to the array returned from this function no longer change the stored `Tw2Vector2Parameter` value array aswell. 
- Added `FillWith` prototype. Removed regex type checking as per Filipp's suggestion.