### PR TITLE
Update EveSpaceScene RenderBatches prototype

### DIFF
--- a/src/eve/EveSpaceScene.js
+++ b/src/eve/EveSpaceScene.js
@@ -141,13 +141,15 @@ EveSpaceScene.prototype.SetEnvMapPath = function (index, path)
     }
 };
 
-EveSpaceScene.prototype.RenderBatches = function (mode, objectArray)
+EveSpaceScene.prototype.RenderBatches = function (mode, objectArray, accumulator)
 {
+    accumulator = (accumulator) ? accumulator : this._batches;
+    
     for (var i = 0; i < objectArray.length; ++i)
     {
         if (typeof (objectArray[i].GetBatches) != 'undefined')
         {
-            objectArray[i].GetBatches(mode, this._batches);
+            objectArray[i].GetBatches(mode, accumulator);
         }
     }
 };


### PR DESCRIPTION
Added optional @param `accumulator` to `EveSpaceScene`'s prototype `RenderBatches`.
This change allows custom render batch accumulators to be used when gathering a scene's render batches. @param `accumulator` defaults to @property `this._batches` so no other changes are required elsewhere to support this.

For example:
```
    scene.Renderbatches(device.RM_OPAQUE, scene.wrappedObjects.objects, pickingAccumulator);
```