### PR TITLE
Removed Redundant Code and Basic Documentation Tw2RuntimeInstanceData

### DIFF
--- a/src/core/Tw2RuntimeInstanceData.js
+++ b/src/core/Tw2RuntimeInstanceData.js
@@ -1,6 +1,14 @@
-function Tw2RuntimeInstanceData() {
+/**
+ * Tw2RuntimeInstanceData
+ * @property {string} name
+ * @property {number} count
+ * @constructor
+ */
+function Tw2RuntimeInstanceData()
+{
     this.name = '';
     this.count = 0;
+
     var declaration = null;
     var vb = null;
     var vertexStride = 0;
@@ -8,24 +16,34 @@ function Tw2RuntimeInstanceData() {
     var data = null;
     var dataDirty = true;
 
-    this.GetMaxInstanceCount = function () {
+    /**
+     * GetMaxInstanceCount
+     * @returns {number}
+     * @method
+     */
+    this.GetMaxInstanceCount = function()
+    {
         return data ? data.length : 1;
     };
-    this.SetElementLayout = function (decl) {
-        declaration = decl;
-        elements = [];
 
+    /**
+     * SetElementLayout
+     * @param decl
+     * @method
+     */
+    this.SetElementLayout = function(decl)
+    {
         if (vb)
         {
             device.gl.deleteBuffer(vb);
             vb = null;
         }
-        declaration = null;
 
         vertexStride = 0;
         declaration = new Tw2VertexDeclaration();
 
-        for (var i = 0; i < decl.length; ++i) {
+        for (var i = 0; i < decl.length; ++i)
+        {
             var element = new Tw2ParticleElementDeclaration();
             element.elementType = decl[i][0];
             element.dimension = decl[i][2];
@@ -39,8 +57,16 @@ function Tw2RuntimeInstanceData() {
 
         declaration.RebuildHash();
     };
-    this.SetData = function (data_) {
-        if (!declaration) {
+
+    /**
+     * SetData
+     * @param data_
+     * @constructor
+     */
+    this.SetData = function(data_)
+    {
+        if (!declaration)
+        {
             return;
         }
         data = data_;
@@ -48,72 +74,150 @@ function Tw2RuntimeInstanceData() {
         dataDirty = true;
         this.UpdateData();
     };
-    this.SetItemElement = function (index, elementIndex, value) {
-        if (declaration.elements[elementIndex].elements > 1) {
-            for (var i = 0; i < declaration.elements[elementIndex].elements; ++i) {
+
+    /**
+     * SetItemElement
+     * @param index
+     * @param elementIndex
+     * @param value
+     * @constructor
+     */
+    this.SetItemElement = function(index, elementIndex, value)
+    {
+        if (declaration.elements[elementIndex].elements > 1)
+        {
+            for (var i = 0; i < declaration.elements[elementIndex].elements; ++i)
+            {
                 data[index][elementIndex][i] = value[i];
             }
         }
-        else {
+        else
+        {
             data[index][elementIndex] = value;
         }
+
         dataDirty = true;
     };
-    this.SetItemElementRef = function (index, elementIndex, value) {
+
+    /**
+     * SetItemElementRef
+     * @param index
+     * @param elementIndex
+     * @param value
+     * @constructor
+     */
+    this.SetItemElementRef = function(index, elementIndex, value)
+    {
         data[index][elementIndex] = value;
         dataDirty = true;
     };
-    this.GetItemElement = function (index, elementIndex) {
+
+    /**
+     * GetItemElement
+     * @param index
+     * @param elementIndex
+     * @returns {*}
+     * @method
+     */
+    this.GetItemElement = function(index, elementIndex)
+    {
         return data[index][elementIndex];
     };
-    this.UpdateData = function () {
-        if (!dataDirty || !declaration) {
+
+    /**
+     * UpdateData
+     * @method
+     */
+    this.UpdateData = function()
+    {
+        if (!dataDirty || !declaration)
+        {
             return;
         }
+
         var vbData = new Float32Array(data.length * vertexStride);
         var offset = 0;
         var i, j, k;
-        for (i = 0; i < data.length; ++i) {
-            for (j = 0; j < declaration.elements.length; ++j) {
-                if (declaration.elements[j].elements == 1) {
+
+        for (i = 0; i < data.length; ++i)
+        {
+            for (j = 0; j < declaration.elements.length; ++j)
+            {
+                if (declaration.elements[j].elements == 1)
+                {
                     vbData[offset++] = data[i][j];
                 }
-                else {
-                    for (k = 0; k < declaration.elements[j].elements; ++k) {
+                else
+                {
+                    for (k = 0; k < declaration.elements[j].elements; ++k)
+                    {
                         vbData[offset++] = data[i][j][k];
                     }
                 }
             }
         }
-        if (!vb) {
+
+        if (!vb)
+        {
             vb = device.gl.createBuffer();
         }
+
         device.gl.bindBuffer(device.gl.ARRAY_BUFFER, vb);
         device.gl.bufferData(device.gl.ARRAY_BUFFER, vbData, device.gl.STATIC_DRAW);
         device.gl.bindBuffer(device.gl.ARRAY_BUFFER, null);
         dataDirty = false;
     };
 
-    this.Unload = function () {
-        if (vb) {
+    /**
+     * Unloads the webgl buffer
+     * @method
+     */
+    this.Unload = function()
+    {
+        if (vb)
+        {
             device.gl.deleteBuffer(vb);
             vb = null;
         }
     };
 
-    this.GetInstanceBuffer = function () {
+    /**
+     * GetInstanceBuffer
+     * @returns {WebglArrayBuffer}
+     * @method
+     */
+    this.GetInstanceBuffer = function()
+    {
         return vb;
     };
 
-    this.GetInstanceDeclaration = function () {
+    /**
+     * GetInstanceDeclaration
+     * @returns {Tw2VertexDeclaration}
+     * @method
+     */
+    this.GetInstanceDeclaration = function()
+    {
         return declaration;
     };
 
-    this.GetInstanceStride = function () {
+    /**
+     * GetInstanceStride
+     * @returns {number}
+     * @method
+     */
+    this.GetInstanceStride = function()
+    {
         return vertexStride * 4;
     };
 
-    this.GetInstanceCount = function () {
+    /**
+     * GetInstanceCount
+     * @returns {number}
+     * @method
+     */
+    this.GetInstanceCount = function()
+    {
         return count;
     };
 }


### PR DESCRIPTION
- Basic Documentation
- Removed redundant code where `elements` was declared and never used anywhere in the constructor, from within the `SetElementLayout` @method
- Removed redundant code where `declaration` was defined three times consecutively in the `SetElementLayout` @method, only the third time was relevant
- Beautified