### PR TITLE
Internet Explorer Fix, Tw2ValueBindingFix, Float32Array Normalization

### DIFF
--- a/src/core/Tw2MatrixParameter.js
+++ b/src/core/Tw2MatrixParameter.js
@@ -1,10 +1,10 @@
 /**
  * Tw2MatrixParameter
  * @param {string} [name='']
- * @param {Array} [value=mat4.create()]
+ * @param {mat4|Float32Array|Array} [value=mat4.create()]
  * @property {string} name
- * @property {Array|mat4} value
- * @property {Array} constantBuffer
+ * @property {mat4|Float32Array} value
+ * @property {Float32Array} constantBuffer
  * @property {number} offset
  * @constructor
  */
@@ -20,12 +20,11 @@ function Tw2MatrixParameter(name, value)
     }
     if (typeof(value) != 'undefined')
     {
-        this.value = value;
+        this.value = mat4.create(value);
     }
     else
     {
-        this.value = mat4.create();
-        mat4.identity(this.value);
+        this.value = mat4.identity(mat4.create());
     }
     this.constantBuffer = null;
     this.offset = 0;
@@ -34,7 +33,7 @@ function Tw2MatrixParameter(name, value)
 /**
  * Bind
  * TODO: Identify if @param size should be passed to the `Apply` prototype as it is currently redundant
- * @param {Array} constantBuffer
+ * @param {Float32Array} constantBuffer
  * @param {number} offset
  * @param {number} size
  * @returns {boolean}
@@ -67,23 +66,23 @@ Tw2MatrixParameter.prototype.SetValue = function(value)
 
 /**
  * Gets the current value
- * @return {Array}
+ * @return {mat4|Float32Array}
  * @prototype
  */
 Tw2MatrixParameter.prototype.GetValue = function()
 {
     if (this.constantBuffer != null)
     {
-        return Array.from(this.constantBuffer.subarray(this.offset, this.offset + this.value.length));
+        return mat4.create(this.constantBuffer.subarray(this.offset, this.offset + this.value.length));
     }
 
-    return Array.from(this.value)
+    return mat4.create(this.value);
 };
 
 /**
  * Applies the current value to the supplied constant buffer at the supplied offset
  * TODO: @param size is currently redundant
- * @param {Array} constantBuffer
+ * @param {Float32Array} constantBuffer
  * @param {number} offset
  * @param {number} size
  * @prototype

--- a/src/core/Tw2MatrixParameter.js
+++ b/src/core/Tw2MatrixParameter.js
@@ -57,7 +57,7 @@ Tw2MatrixParameter.prototype.Bind = function(constantBuffer, offset, size)
  */
 Tw2MatrixParameter.prototype.SetValue = function(value)
 {
-    this.value = value;
+    this.value = mat4.create(value);
     if (this.constantBuffer != null)
     {
         this.constantBuffer.set(this.value, this.offset);

--- a/src/core/Tw2ValueBinding.js
+++ b/src/core/Tw2ValueBinding.js
@@ -156,8 +156,8 @@ Tw2ValueBinding.prototype.Initialize = function()
         return;
     }
 
-    var srcIsArray = this.sourceObject[this.sourceAttribute].constructor == (new Float32Array()).constructor;
-    var destIsArray = this.destinationObject[this.destinationAttribute].constructor == (new Float32Array()).constructor;
+    var srcIsArray = (this.sourceObject[this.sourceAttribute].constructor == (new Float32Array()).constructor || this.sourceObject[this.sourceAttribute].constructor.name == "Array");
+    var destIsArray = (this.destinationObject[this.destinationAttribute].constructor == (new Float32Array()).constructor || this.destinationObject[this.destinationAttribute].constructor.name == "Array");
 
     if (srcIsArray == destIsArray && typeof this.sourceObject[this.sourceAttribute] == typeof this.destinationObject[this.destinationAttribute])
     {

--- a/src/core/Tw2Vector2Parameter.js
+++ b/src/core/Tw2Vector2Parameter.js
@@ -1,10 +1,10 @@
 /**
  * Tw2Vector2Parameter
  * @param {string} [name='']
- * @param {Vector2} [value=[1,1]]
+ * @param {Array|Float32Array} [value=[1,1]]
  * @property {string} name
- * @property {Vector2} value
- * @property {Array} constantBuffer
+ * @property {Float32Array} value
+ * @property {Float32Array} constantBuffer
  * @property {number} offset
  * @constructor
  */
@@ -20,7 +20,7 @@ function Tw2Vector2Parameter(name, value)
     }
     if (typeof(value) != 'undefined')
     {
-        this.value = value;
+        this.value = new Float32Array(value);
     }
     else
     {
@@ -33,7 +33,7 @@ function Tw2Vector2Parameter(name, value)
 /**
  * Bind
  * TODO: Identify if @param size should be passed to the `Apply` prototype as it is currently redundant
- * @param {Array} constantBuffer
+ * @param {Float32Array} constantBuffer
  * @param {number} offset
  * @param {number} size
  * @returns {boolean}
@@ -67,7 +67,7 @@ Tw2Vector2Parameter.prototype.Unbind = function()
  */
 Tw2Vector2Parameter.prototype.SetValue = function(value)
 {
-    this.value = value;
+    this.value.set(value);
     if (this.constantBuffer != null)
     {
         this.constantBuffer.set(this.value, this.offset);
@@ -89,7 +89,7 @@ Tw2Vector2Parameter.prototype.OnValueChanged = function()
 /**
  * Applies the current value to the supplied constant buffer at the supplied offset
  * TODO: @param size is currently redundant
- * @param {Array} constantBuffer
+ * @param {Float32Array} constantBuffer
  * @param {number} offset
  * @param {number} size
  * @prototype
@@ -101,17 +101,17 @@ Tw2Vector2Parameter.prototype.Apply = function(constantBuffer, offset, size)
 
 /**
  * Gets the current value array
- * @return {Array} Vector2 Array
+ * @return {Float32Array} Vector2 Array
  * @prototype
  */
 Tw2Vector2Parameter.prototype.GetValue = function()
 {
     if (this.constantBuffer != null)
     {
-        return Array.from(this.constantBuffer.subarray(this.offset, this.offset + this.value.length));
+        return new Float32Array((this.constantBuffer.subarray(this.offset, this.offset + this.value.length)));
     }
 
-    return Array.from(this.value);
+    return new Float32Array(this.value);
 };
 
 /**

--- a/src/core/Tw2Vector3Parameter.js
+++ b/src/core/Tw2Vector3Parameter.js
@@ -1,10 +1,10 @@
 /**
  * Tw2Vector3Parameter
  * @param {string} [name='']
- * @param {Vector3} [value=[1,1,1]]
+ * @param {vec3|Float32Array} [value=[1,1,1]]
  * @property {string} name
- * @property {Vector3} value
- * @property {Array} constantBuffer
+ * @property {vec3|Float32Array} value
+ * @property {Float32Array} constantBuffer
  * @property {number} offset
  * @constructor
  */
@@ -33,7 +33,7 @@ function Tw2Vector3Parameter(name, value)
 /**
  * Bind
  * TODO: Identify if @param size should be passed to the `Apply` prototype as it is currently redundant
- * @param {Array} constantBuffer
+ * @param {Float32Array} constantBuffer
  * @param {number} offset
  * @param {number} size
  * @returns {boolean}
@@ -62,12 +62,12 @@ Tw2Vector3Parameter.prototype.Unbind = function()
 
 /**
  * Sets a supplied value
- * @param {Array} value - Vector3 Array
+ * @param {vec3|Float32Array} value - Vector3 Array
  * @prototype
  */
 Tw2Vector3Parameter.prototype.SetValue = function(value)
 {
-    this.value = value;
+    this.value.set(value);
     if (this.constantBuffer != null)
     {
         this.constantBuffer.set(this.value, this.offset);
@@ -89,7 +89,7 @@ Tw2Vector3Parameter.prototype.OnValueChanged = function()
 /**
  * Applies the current value to the supplied constant buffer at the supplied offset
  * TODO: @param size is currently redundant
- * @param {Array} constantBuffer
+ * @param {Float32Array} constantBuffer
  * @param {number} offset
  * @param {number} size
  * @prototype
@@ -101,17 +101,17 @@ Tw2Vector3Parameter.prototype.Apply = function(constantBuffer, offset, size)
 
 /**
  * Gets the current value array
- * @return {Array} Vector3 Array
+ * @return {vec3|Float32Array} Vector3 Array
  * @prototype
  */
 Tw2Vector3Parameter.prototype.GetValue = function()
 {
     if (this.constantBuffer != null)
     {
-        return Array.from(this.constantBuffer.subarray(this.offset, this.offset + this.value.length));
+        return vec3.create(this.constantBuffer.subarray(this.offset, this.offset + this.value.length));
     }
 
-    return Array.from(this.value);
+    return vec3.create(this.value);
 };
 
 /**

--- a/src/core/Tw2Vector4Parameter.js
+++ b/src/core/Tw2Vector4Parameter.js
@@ -1,9 +1,9 @@
 /**
  * Tw2Vector4Parameter
  * @param {string} [name='']
- * @param {quat4} [value=[1,1,1,1]]
+ * @param {quat4|Float32Array} [value=[1,1,1,1]]
  * @property {string} name
- * @property {quat4} value
+ * @property {quat4|Float32Array} value
  * @property {Array} constantBuffer
  * @property {number} offset
  * @constructor
@@ -20,7 +20,7 @@ function Tw2Vector4Parameter(name, value)
     }
     if (typeof(value) != 'undefined')
     {
-        this.value = value;
+        this.value = quat4.create(value);
     }
     else
     {
@@ -33,7 +33,7 @@ function Tw2Vector4Parameter(name, value)
 /**
  * Bind
  * TODO: Identify if @param size should be passed to the `Apply` prototype as it is currently redundant
- * @param {Array} constantBuffer
+ * @param {Float32Array} constantBuffer
  * @param {number} offset
  * @param {number} size
  * @returns {boolean}
@@ -62,12 +62,12 @@ Tw2Vector4Parameter.prototype.Unbind = function()
 
 /**
  * Sets a supplied value
- * @param {Array} value - Vector4 Array
+ * @param {quat4|Float32Array|Array} value - Vector4 Array
  * @prototype
  */
 Tw2Vector4Parameter.prototype.SetValue = function(value)
 {
-    this.value = value;
+    this.value.set(value);
     if (this.constantBuffer != null)
     {
         this.constantBuffer.set(this.value, this.offset);
@@ -89,7 +89,7 @@ Tw2Vector4Parameter.prototype.OnValueChanged = function()
 /**
  * Applies the current value to the supplied constant buffer at the supplied offset
  * TODO: @param size is currently redundant
- * @param {Array} constantBuffer
+ * @param {Float32Array} constantBuffer
  * @param {number} offset
  * @param {number} size
  * @prototype
@@ -101,17 +101,17 @@ Tw2Vector4Parameter.prototype.Apply = function(constantBuffer, offset, size)
 
 /**
  * Gets the current value array
- * @return {Array} Vector4 Array
+ * @return {quat4|Float32Array} Vector4 Array
  * @prototype
  */
 Tw2Vector4Parameter.prototype.GetValue = function()
 {
     if (this.constantBuffer != null)
     {
-        return Array.from(this.constantBuffer.subarray(this.offset, this.offset + this.value.length));
+        return quat4.create(this.constantBuffer.subarray(this.offset, this.offset + this.value.length));
     }
 
-    return Array.from(this.value);
+    return quat4.create(this.value);
 };
 
 /**


### PR DESCRIPTION
**Tw2Vector2Parameter**, **Tw2Vector3Parameter**, **Tw2Vector4Parameter**, **Tw2MatrixParameter**:
- All stored `this.value` arrays are now always `Float32Array`s
- All returned values are now always `Float32Array`s (removed `Array.from` that I added which IE doesn't support)
- All `Set` prototypes now use  `this.value.set(value)` rather than `this.value = value` to ensure they're always stored as `Float32Array`s

**Tw2ValueBinding**
- Fixed an issue with the `Tw2ValueBinding` constructor: When binding a normal array no `_copyFunc` would be picked during initialization. The above changes also solved this problem, however a user may want to bind their own normal arrays.