### PR TITLE
Changed EveSpaceObjectDecal groupIndex Default

### DIFF
--- a/src/eve/EveSpaceObjectDecal.js
+++ b/src/eve/EveSpaceObjectDecal.js
@@ -3,7 +3,7 @@ function EveSpaceObjectDecal()
     this.display = true;
     this.decalEffect = null;
     this.name = '';
-    this.groupIndex = null;
+    this.groupIndex = -1;
     
     this.position = vec3.create();
     this.rotation = quat4.create();


### PR DESCRIPTION
- Set the `groupIndex` property to `-1`
- Not necessary but keeps it inline with the other sets that use `groupIndex`, and removes the need to set it to `-1` when building an object with the SOF.