### PR TITLE
Add `GetValue` to Tw2TextureParameter

### DIFF
--- a/src/core/Tw2TextureParameter.js
+++ b/src/core/Tw2TextureParameter.js
@@ -144,3 +144,17 @@ Tw2TextureParameter.prototype.Apply = function(stage, sampler, slices)
         this.textureRes.Bind(sampler, slices);
     }
 };
+
+/**
+ * Get Value
+ * @return {string}
+ */
+ Tw2TextureParameter.prototype.GetValue = function()
+ {
+     if (this.textureRes)
+     {
+         return this.textureRes.path;
+     }
+     
+     return this.resourcePath;
+ }


### PR DESCRIPTION
- Added `GetValue` prototype to make it consistant with other Tw2 Parameters

Is there a reason why `Tw2TextureParameter` couldn't have a `SetValue` wrapper for `SetTexturePath` also?
```
/**
 * Set Value (Wrapper for SetTexturePath)
 * @return {string}
 */
 Tw2TextureParameter.prototype.SetValue = function(texturePath)
 {
     this.SetTexturePath(texturePath);
 }
```