### PR TITLE
New Prototypes and Properties to Tw2TransformParameter

### DIFF
--- a/src/core/Tw2TransformParameter.js
+++ b/src/core/Tw2TransformParameter.js
@@ -1,4 +1,69 @@
 /**
+ * Converts a quat to vec3
+ * @param {quat4} quat
+ * @return {vec3}
+ */
+function quatToEuler(quat)
+{
+    var euler = vec3.create([0,0,0]);
+    var qx = parseFloat(quat[0]);
+    var qy = parseFloat(quat[1]);
+    var qz = parseFloat(quat[2]);
+    var qw = parseFloat(quat[3]);
+    var qw2 = qw * qw;
+    var qx2 = qx * qx;
+    var qy2 = qy * qy;
+    var qz2 = qz * qz;
+    var test = qx * qy + qz * qw;
+    if (test > 0.499)
+    {
+        euler[0] = 0;
+        euler[1] = 360 / Math.PI * Math.atan2(qx, qw);
+        euler[2] = 90;
+        return euler;
+    }
+    if (test < -0.499)
+    {
+        euler[0] = 0;
+        euler[1] = -360 / Math.PI * Math.atan2(qx, qw);
+        euler[2] = -90;
+        return euler;
+    }
+
+    var h = Math.atan2(2 * qy * qw - 2 * qx * qz, 1 - 2 * qy2 - 2 * qz2);
+    var a = Math.asin(2 * qx * qy + 2 * qz * qw);
+    var b = Math.atan2(2 * qx * qw - 2 * qy * qz, 1 - 2 * qx2 - 2 * qz2);
+    euler[0] = Math.round(b * 180 / Math.PI);
+    euler[1] = Math.round(h * 180 / Math.PI);
+    euler[2] = Math.round(a * 180 / Math.PI);
+    return euler;
+}
+
+/**
+ *  Converts a vec3 to quat4
+ *  @array {vec3} euler
+ *  @return {quat4}
+ */
+function eulerToQuat(euler)
+{
+    var quat = quat4.create([0, 0, 0, 0]);
+    var b = parseFloat(euler[0]) * Math.PI / 360;
+    var h = parseFloat(euler[1]) * Math.PI / 360;
+    var a = parseFloat(euler[2]) * Math.PI / 360;
+    var c1 = Math.cos(h);
+    var c2 = Math.cos(a);
+    var c3 = Math.cos(b);
+    var s1 = Math.sin(h);
+    var s2 = Math.sin(a);
+    var s3 = Math.sin(b);
+    quat[0] = Math.round((s1 * s2 * c3 + c1 * c2 * s3) * 100000) / 100000;
+    quat[1] = Math.round((s1 * c2 * c3 + c1 * s2 * s3) * 100000) / 100000;
+    quat[2] = Math.round((c1 * s2 * c3 - s1 * c2 * s3) * 100000) / 100000;
+    quat[3] = Math.round((c1 * c2 * c3 - s1 * s2 * s3) * 100000) / 100000;
+    return quat;
+}
+
+/**
  * Tw2TransformParameter
  * @param {string} [name='']
  * @parameter {string} name
@@ -6,6 +71,8 @@
  * @parameter {quat4} rotation=[0,0,0,1]
  * @parameter {vec3} translation=[0,0,0]
  * @parameter {mat4} worldTransform
+ * @parameter {mat4} _transform
+ * @parameter {mat4} target
  * @constructor
  */
 function Tw2TransformParameter(name)
@@ -23,6 +90,8 @@ function Tw2TransformParameter(name)
     this.rotation = quat4.create([0, 0, 0, 1]);
     this.translation = vec3.create([0, 0, 0]);
     this.worldTransform = mat4.identity(mat4.create());
+    this._transform = mat4.identity(mat4.create());
+    this._target = null;
 }
 
 /**
@@ -66,7 +135,14 @@ Tw2TransformParameter.prototype.OnModified = function()
     mat4.multiply(this.worldTransform, rotation);
     mat4.multiply(this.worldTransform, rotationCenter);
     mat4.translate(this.worldTransform, this.translation);
+
+    this._transform.set(this.worldTransform);
     mat4.transpose(this.worldTransform);
+    
+    if (this._target)
+    {
+        this.target.setTransform(this._transform);
+    }
 };
 
 /**
@@ -115,3 +191,149 @@ Tw2TransformParameter.prototype.Apply = function(constantBuffer, offset, size)
         constantBuffer.set(this.worldTransform.subarray(0, size), offset);
     }
 };
+
+/**
+ * Sets an optional target spaceObject
+ * @param {{}}} spaceObject
+ * @returns {boolean} 
+ */
+Tw2TransformParameter.prototype.SetTarget = function(spaceObject)
+{
+    if ('setTransform' in spaceObject)
+    {
+        this._target = spaceObject;
+        return true;
+    }
+    return false;
+}
+
+/**
+ * Gets the target
+ * @returns {{}}} 
+ */
+Tw2TransformParameter.prototype.GetTarget = function()
+{
+    return this._target;
+}
+
+/**
+ * Clears the target
+ */
+Tw2TransformParameter.prototype.RemoveTarget = function()
+{
+    this._target = null;
+}
+
+
+/**
+ * Sets scale
+ * @param {vec3} vec3
+ */
+Tw2TransformParameter.prototype.SetScale = function(vec3)
+{     
+    this.scaling.set(vec3);
+    this.OnModified();
+}
+
+/**
+ * Gets scale
+ * @return {vec3}
+ */
+Tw2TransformParameter.prototype.GetScale = function()
+{     
+    return vec3.create(this.scaling);
+}
+
+/**
+ * Sets position
+ * @param {vec3} vec3
+ */
+Tw2TransformParameter.prototype.SetPosition = function(vec3)
+{     
+    this.translation.set(vec3);
+    this.OnModified();
+}
+
+/**
+ * Gets position
+ * @return {vec3}
+ */
+Tw2TransformParameter.prototype.GetPosition = function()
+{     
+    return vec3.create(this.translation);
+}
+ 
+/**
+ * Sets rotation from a vec3
+ * @param {vec3} vec3
+ */
+Tw2TransformParameter.prototype.SetRotation = function(vec3)
+{
+    this.rotation.set(eulerToQuat(vec3));
+    this.OnModified();
+}
+
+/**
+ * Gets rotation as a vec3
+ * @return {vec3}
+ */
+Tw2TransformParameter.prototype.GetRotation = function()
+{     
+    return vec3.create(quatToEuler(this.rotation));
+}
+
+/**
+ * Sets rotation from a quat4
+ * @param {vec3} 
+ */
+Tw2TransformParameter.prototype.SetOrientation = function(quat4)
+{
+    this.rotation.set(quat4);
+    this.OnModified();
+}
+
+/**
+ * Gets rotation as a quat4
+ * @param {quat4} 
+ */
+Tw2TransformParameter.prototype.GetOrientation = function()
+{
+    return quat4.create(this.rotation);
+}
+
+/**
+ * Sets rotation center
+ * @param {vec3} vec3
+ */
+Tw2TransformParameter.prototype.SetCenter = function(vec3)
+{
+    this.rotationCenter.set(vec3);
+    this.OnModified();
+}
+
+/**
+ * Gets rotation center
+ * @return {vec3} 
+ */
+Tw2TransformParameter.prototype.GetCenter = function()
+{
+    return vec3.create(this.rotationCenter);
+}
+
+/**
+ * Gets current transform
+ * @return {vec3} 
+ */
+Tw2TransformParameter.prototype.GetTransform = function()
+{
+    return mat4.create(this._transform);
+}
+
+/**
+ * Gets current worldtransform
+ * @return {vec3} 
+ */
+Tw2TransformParameter.prototype.GetWorld = function()
+{
+    return mat4.create(this.worldTransform);
+}

--- a/src/core/Tw2TransformParameter.js
+++ b/src/core/Tw2TransformParameter.js
@@ -41,7 +41,7 @@ function quatToEuler(quat)
 
 /**
  *  Converts a vec3 to quat4
- *  @array {vec3} euler
+ *  @param {vec3} euler
  *  @return {quat4}
  */
 function eulerToQuat(euler)
@@ -194,7 +194,7 @@ Tw2TransformParameter.prototype.Apply = function(constantBuffer, offset, size)
 
 /**
  * Sets an optional target spaceObject
- * @param {{}}} spaceObject
+ * @param {{}} spaceObject
  * @returns {boolean} 
  */
 Tw2TransformParameter.prototype.SetTarget = function(spaceObject)
@@ -205,16 +205,16 @@ Tw2TransformParameter.prototype.SetTarget = function(spaceObject)
         return true;
     }
     return false;
-}
+};
 
 /**
  * Gets the target
- * @returns {{}}} 
+ * @returns {{}} 
  */
 Tw2TransformParameter.prototype.GetTarget = function()
 {
     return this._target;
-}
+};
 
 /**
  * Clears the target
@@ -222,8 +222,7 @@ Tw2TransformParameter.prototype.GetTarget = function()
 Tw2TransformParameter.prototype.RemoveTarget = function()
 {
     this._target = null;
-}
-
+};
 
 /**
  * Sets scale
@@ -233,7 +232,7 @@ Tw2TransformParameter.prototype.SetScale = function(vec3)
 {     
     this.scaling.set(vec3);
     this.OnModified();
-}
+};
 
 /**
  * Gets scale
@@ -242,7 +241,7 @@ Tw2TransformParameter.prototype.SetScale = function(vec3)
 Tw2TransformParameter.prototype.GetScale = function()
 {     
     return vec3.create(this.scaling);
-}
+};
 
 /**
  * Sets position
@@ -252,7 +251,7 @@ Tw2TransformParameter.prototype.SetPosition = function(vec3)
 {     
     this.translation.set(vec3);
     this.OnModified();
-}
+};
 
 /**
  * Gets position
@@ -261,7 +260,7 @@ Tw2TransformParameter.prototype.SetPosition = function(vec3)
 Tw2TransformParameter.prototype.GetPosition = function()
 {     
     return vec3.create(this.translation);
-}
+};
  
 /**
  * Sets rotation from a vec3
@@ -271,7 +270,7 @@ Tw2TransformParameter.prototype.SetRotation = function(vec3)
 {
     this.rotation.set(eulerToQuat(vec3));
     this.OnModified();
-}
+};
 
 /**
  * Gets rotation as a vec3
@@ -280,7 +279,7 @@ Tw2TransformParameter.prototype.SetRotation = function(vec3)
 Tw2TransformParameter.prototype.GetRotation = function()
 {     
     return vec3.create(quatToEuler(this.rotation));
-}
+};
 
 /**
  * Sets rotation from a quat4
@@ -290,7 +289,7 @@ Tw2TransformParameter.prototype.SetOrientation = function(quat4)
 {
     this.rotation.set(quat4);
     this.OnModified();
-}
+};
 
 /**
  * Gets rotation as a quat4
@@ -299,7 +298,7 @@ Tw2TransformParameter.prototype.SetOrientation = function(quat4)
 Tw2TransformParameter.prototype.GetOrientation = function()
 {
     return quat4.create(this.rotation);
-}
+};
 
 /**
  * Sets rotation center
@@ -309,7 +308,7 @@ Tw2TransformParameter.prototype.SetCenter = function(vec3)
 {
     this.rotationCenter.set(vec3);
     this.OnModified();
-}
+};
 
 /**
  * Gets rotation center
@@ -318,7 +317,7 @@ Tw2TransformParameter.prototype.SetCenter = function(vec3)
 Tw2TransformParameter.prototype.GetCenter = function()
 {
     return vec3.create(this.rotationCenter);
-}
+};
 
 /**
  * Gets current transform
@@ -327,7 +326,7 @@ Tw2TransformParameter.prototype.GetCenter = function()
 Tw2TransformParameter.prototype.GetTransform = function()
 {
     return mat4.create(this._transform);
-}
+};
 
 /**
  * Gets current worldtransform
@@ -336,4 +335,4 @@ Tw2TransformParameter.prototype.GetTransform = function()
 Tw2TransformParameter.prototype.GetWorld = function()
 {
     return mat4.create(this.worldTransform);
-}
+};

--- a/src/core/Tw2TransformParameter.js
+++ b/src/core/Tw2TransformParameter.js
@@ -141,7 +141,7 @@ Tw2TransformParameter.prototype.OnModified = function()
     
     if (this._target)
     {
-        this.target.setTransform(this._transform);
+        this._target.setTransform(this._transform);
     }
 };
 


### PR DESCRIPTION
- These changes do not effect anything currently using this Constructor
- Added @function `eulerToQuat` which converts a vec3 to quat4 
- Added @function `quatToEuler` which converts a quat4 to vec3 
- Added @property `_transform` which holds an un-transposed version of the `worldTransform`
- Added @property `_target` which stores an optional wrapped SpaceObject
- Added `SetTarget`, `GetTarget` and `ClearTarget` prototypes
- Added `GetScale` and `SetScale` prototypes 
- Added `GetPosition` and `SetPosition` prototypes
- Added `GetRotation` and `SetRotation` prototypes (vec3 rotation)
- Added `GetOrientation` and `SetOrientation` prototypes (quat4 rotation)
- Added `GetCenter` and `SetCenter` prototypes 
- Added `GetTransform` prototype which returns an untransposed transform
- Added `GetWorld` prototype which returns the current world transform