### PR TITLE
New Prototypes and Updates to Tw2AnimationController

### DIFF
--- a/src/core/Tw2AnimationController.js
+++ b/src/core/Tw2AnimationController.js
@@ -330,15 +330,14 @@ Tw2AnimationController.prototype.RebuildCachedData = function(resource)
 
 /**
  * _DoRebuildCachedData
- * TODO: Fix commented out code (line 339)
- * TODO: Too many arguments supplied to this.AddAnimationsFromRes prototype (line 352)
+ * TODO: Too many arguments supplied to this.AddAnimationsFromRes prototype
  * @param {Tw2GeometryRes} resource
  * @private
  */
 Tw2AnimationController.prototype._DoRebuildCachedData = function(resource)
 {
     var newModels = [];
-    //if (resource.meshes.length)
+    if (resource.meshes.length)
     {
         for (var i = 0; i < resource.models.length; ++i)
         {
@@ -493,7 +492,7 @@ Tw2AnimationController.prototype.PlayAnimation = function(name, cycle, callback)
             'func': this.PlayAnimation,
             'args': [name, cycle, callback]
         });
-        return;
+        return true;
     }
 
     var animation = this.GetAnimation(name);
@@ -538,7 +537,7 @@ Tw2AnimationController.prototype.PlayAnimationFrom = function(name, from, cycle,
             'func': this.PlayAnimationFrom,
             'args': [name, from, cycle, callback]
         });
-        return;
+        return true;
     }
 
     var animation = this.GetAnimation(name);
@@ -600,7 +599,7 @@ Tw2AnimationController.prototype.StopAnimation = function(names)
             'func': this.StopAnimation,
             'args': names
         });
-        return;
+        return true;
     }
 
     if (typeof names == 'string' || names instanceof String)
@@ -672,7 +671,7 @@ Tw2AnimationController.prototype.StopAllAnimationsExcept = function(names)
             'func': this.StopAllAnimationsExcept,
             'args': names
         });
-        return;
+        return true;
     }
 
     if (typeof names == 'string' || names instanceof String)

--- a/src/core/Tw2AnimationController.js
+++ b/src/core/Tw2AnimationController.js
@@ -106,6 +106,7 @@ function Tw2Model()
  * @property {quat4} _tempQuat4
  * @property {vec3} _tempVec3
  * @property _geometryResource
+ * @property {Array} pendingCommands
  * @prototype
  */
 function Tw2AnimationController(geometryResource)
@@ -121,6 +122,7 @@ function Tw2AnimationController(geometryResource)
     this._tempQuat4 = quat4.create();
     this._tempVec3 = vec3.create();
     this._geometryResource = null;
+    this.pendingCommands = [];
 
     if (typeof(geometryResource) != 'undefined')
     {
@@ -416,7 +418,7 @@ Tw2AnimationController.prototype._DoRebuildCachedData = function(resource)
     this.loaded = true;
     if (this.animations.length)
     {
-        if (this.pendingCommands)
+        if (this.pendingCommands.length)
         {
             for (var i = 0; i < this.pendingCommands.length; ++i)
             {
@@ -430,7 +432,7 @@ Tw2AnimationController.prototype._DoRebuildCachedData = function(resource)
                 }
             }
         }
-        this.pendingCommands = null;
+        this.pendingCommands = [];
     }
 };
 
@@ -483,10 +485,6 @@ Tw2AnimationController.prototype.PlayAnimation = function(name, cycle, callback)
 {
     if (this.animations.length == 0)
     {
-        if (!this.pendingCommands)
-        {
-            this.pendingCommands = [];
-        }
         this.pendingCommands.push(
         {
             'func': this.PlayAnimation,
@@ -526,10 +524,6 @@ Tw2AnimationController.prototype.PlayAnimationFrom = function(name, from, cycle,
 {
     if (this.animations.length == 0)
     {
-        if (!this.pendingCommands)
-        {
-            this.pendingCommands = [];
-        }
         this.pendingCommands.push(
         {
             'func': this.PlayAnimationFrom,
@@ -587,10 +581,6 @@ Tw2AnimationController.prototype.StopAnimation = function(names)
 {
     if (this.animations.length == 0)
     {
-        if (!this.pendingCommands)
-        {
-            this.pendingCommands = [];
-        }
         this.pendingCommands.push(
         {
             'func': this.StopAnimation,
@@ -628,10 +618,6 @@ Tw2AnimationController.prototype.StopAllAnimations = function()
 {
     if (this.animations.length == 0)
     {
-        if (!this.pendingCommands)
-        {
-            this.pendingCommands = [];
-        }
         this.pendingCommands.push(
         {
             'func': this.StopAllAnimations,
@@ -655,10 +641,6 @@ Tw2AnimationController.prototype.StopAllAnimationsExcept = function(names)
 {
     if (this.animations.length == 0)
     {
-        if (!this.pendingCommands)
-        {
-            this.pendingCommands = [];
-        }
         this.pendingCommands.push(
         {
             'func': this.StopAllAnimationsExcept,

--- a/src/core/Tw2AnimationController.js
+++ b/src/core/Tw2AnimationController.js
@@ -509,10 +509,8 @@ Tw2AnimationController.prototype.PlayAnimation = function(name, cycle, callback)
         {
             animation.callback = callback;
         }
-
         return true;
     }
-
 };
 
 /**
@@ -583,7 +581,6 @@ Tw2AnimationController.prototype.GetPlayingAnimations = function()
 /**
  * Stops an animation or an array of animations from playing
  * @param {String, Array.<string>} names - Animation Name, or Array of Animation Names
- * @return {boolean}
  * @prototype
  */
 Tw2AnimationController.prototype.StopAnimation = function(names)
@@ -599,7 +596,7 @@ Tw2AnimationController.prototype.StopAnimation = function(names)
             'func': this.StopAnimation,
             'args': names
         });
-        return true;
+        return;
     }
 
     if (typeof names == 'string' || names instanceof String)
@@ -607,22 +604,19 @@ Tw2AnimationController.prototype.StopAnimation = function(names)
         names = [names];
     }
 
-    if (names && Object.prototype.toString.apply(names) === '[object Array]')
+    var toStop = {};
+    
+    for (var n = 0; n < names.length; n++)
     {
-        var toStop = {};
-        for (var n = 0; n < names.length; n++)
-        {
-            toStop[names[n]] = true;
-        }
+        toStop[names[n]] = true;
+    }
 
-        for (var i = 0; i < this.animations.length; ++i)
+    for (var i = 0; i < this.animations.length; ++i)
+    {
+        if (this.animations[i].animationRes.name in toStop)
         {
-            if (this.animations[i].animationRes.name in toStop)
-            {
-                this.animations[i].isPlaying = false;
-            }
+            this.animations[i].isPlaying = false;
         }
-        return true;
     }
 };
 
@@ -655,7 +649,6 @@ Tw2AnimationController.prototype.StopAllAnimations = function()
 /**
  * Stops all but the supplied list of animations
  * @param {String| Array.<string>} names - Animation Names
- * @returns {null|boolean}
  * @prototype
  */
 Tw2AnimationController.prototype.StopAllAnimationsExcept = function(names)
@@ -671,7 +664,7 @@ Tw2AnimationController.prototype.StopAllAnimationsExcept = function(names)
             'func': this.StopAllAnimationsExcept,
             'args': names
         });
-        return true;
+        return;
     }
 
     if (typeof names == 'string' || names instanceof String)
@@ -679,22 +672,19 @@ Tw2AnimationController.prototype.StopAllAnimationsExcept = function(names)
         names = [names];
     }
 
-    if (names && Object.prototype.toString.apply(names) === '[object Array]')
+    var keepAnimating = {};
+    
+    for (var n = 0; n < names.length; n++)
     {
-        var keepAnimating = {};
-        for (var n = 0; n < names.length; n++)
-        {
-            keepAnimating[names[n]] = true;
-        }
+        keepAnimating[names[n]] = true;
+    }
 
-        for (var i = 0; i < this.animations.length; ++i)
+    for (var i = 0; i < this.animations.length; ++i)
+    {
+        if (!(this.animations[i].animationRes.name in keepAnimating))
         {
-            if (!(this.animations[i].animationRes.name in keepAnimating))
-            {
-                this.animations[i].isPlaying = false;
-            }
+            this.animations[i].isPlaying = false;
         }
-        return true;
     }
 };
 


### PR DESCRIPTION
- Added support for pending commands that have no arguments `_DoRebuildCachedData` @prototype
- Added `GetAnimation` @prototype which returns a loaded `Tw2Animation` by it's name, used this prototype to simplify some of the others
- Added `ResetAnimation` @prototype which resets a loaded `Tw2Animation` by it's name
- Added `PlayAnimationFrom` @prototype which plays a loaded `Tw2Animation` from a specific time. (Didn't update the existing `PlayAnimation` as it could break people's existing code)
- Updated `StopAnimation` @prototype so that it can also take a list of `Tw2Animation` names aswell as just a single name. It can now also be called before any animations have been loaded, and will stop them when they have
- Updated `StopAllAnimations` @prototype so that it can now be called before any animations have been loaded, and will stop them when they have
- Added `StopAllAnimationsExcept` @prototype that stops all `Tw2Animation`s except those that are supplied by name in an array
- Made changes to @type checking as per Filipp's suggestions
- Simplified functions a little by some changes to the `pendingCommand` @property