### PR TITLE
Fixes and Basic Docs EveSpriteSet, Updated EveSpriteSetItem

### DIFF
--- a/src/eve/EveSpriteSet.js
+++ b/src/eve/EveSpriteSet.js
@@ -46,8 +46,17 @@ EveSpriteSet.prototype.Initialize = function()
 EveSpriteSet.prototype.RebuildBuffers = function()
 {
     var vertexSize = 13;
-    var array = new Float32Array(this.sprites.length * 4 * vertexSize);
-    for (var i = 0; i < this.sprites.length; ++i)
+    var visibleItems = [];
+    for (var i = 0; i < this.sprites.length; i++)
+    {
+        if (this.sprites[i].display)
+        {
+            visibleItems.push(this.sprites[i]);
+        }
+    }
+
+    var array = new Float32Array(visibleItems.length * 4 * vertexSize);
+    for (var i = 0; i < visibleItems.length; ++i)
     {
         var offset = i * 4 * vertexSize;
         array[offset + 0 * vertexSize] = 0;
@@ -57,18 +66,18 @@ EveSpriteSet.prototype.RebuildBuffers = function()
         for (var j = 0; j < 4; ++j)
         {
             var vtxOffset = offset + j * vertexSize;
-            array[vtxOffset + 1] = this.sprites[i].boneIndex;
-            array[vtxOffset + 2] = this.sprites[i].position[0];
-            array[vtxOffset + 3] = this.sprites[i].position[1];
-            array[vtxOffset + 4] = this.sprites[i].position[2];
-            array[vtxOffset + 5] = this.sprites[i].color[0];
-            array[vtxOffset + 6] = this.sprites[i].color[1];
-            array[vtxOffset + 7] = this.sprites[i].color[2];
-            array[vtxOffset + 8] = this.sprites[i].blinkPhase;
-            array[vtxOffset + 9] = this.sprites[i].blinkRate;
-            array[vtxOffset + 10] = this.sprites[i].minScale;
-            array[vtxOffset + 11] = this.sprites[i].maxScale;
-            array[vtxOffset + 12] = this.sprites[i].falloff;
+            array[vtxOffset + 1] = visibleItems[i].boneIndex;
+            array[vtxOffset + 2] = visibleItems[i].position[0];
+            array[vtxOffset + 3] = visibleItems[i].position[1];
+            array[vtxOffset + 4] = visibleItems[i].position[2];
+            array[vtxOffset + 5] = visibleItems[i].color[0];
+            array[vtxOffset + 6] = visibleItems[i].color[1];
+            array[vtxOffset + 7] = visibleItems[i].color[2];
+            array[vtxOffset + 8] = visibleItems[i].blinkPhase;
+            array[vtxOffset + 9] = visibleItems[i].blinkRate;
+            array[vtxOffset + 10] = visibleItems[i].minScale;
+            array[vtxOffset + 11] = visibleItems[i].maxScale;
+            array[vtxOffset + 12] = visibleItems[i].falloff;
         }
     }
     this._vertexBuffer = device.gl.createBuffer();
@@ -76,8 +85,8 @@ EveSpriteSet.prototype.RebuildBuffers = function()
     device.gl.bufferData(device.gl.ARRAY_BUFFER, array, device.gl.STATIC_DRAW);
     device.gl.bindBuffer(device.gl.ARRAY_BUFFER, null);
 
-    var indexes = new Uint16Array(this.sprites.length * 6);
-    for (var i = 0; i < this.sprites.length; ++i)
+    var indexes = new Uint16Array(visibleItems.length * 6);
+    for (var i = 0; i < visibleItems.length; ++i)
     {
         var offset = i * 6;
         var vtxOffset = i * 4;
@@ -92,7 +101,7 @@ EveSpriteSet.prototype.RebuildBuffers = function()
     device.gl.bindBuffer(device.gl.ELEMENT_ARRAY_BUFFER, this._indexBuffer);
     device.gl.bufferData(device.gl.ELEMENT_ARRAY_BUFFER, indexes, device.gl.STATIC_DRAW);
     device.gl.bindBuffer(device.gl.ELEMENT_ARRAY_BUFFER, null);
-    this._indexBuffer.count = this.sprites.length * 6;
+    this._indexBuffer.count = visibleItems.length * 6;
 };
 
 /**
@@ -141,7 +150,7 @@ EveSpriteSet.prototype.GetBatches = function(mode, accumulator, perObjectData)
  */
 EveSpriteSet.prototype.Render = function(overrideEffect)
 {
-    var effect = (!overrideEffect) ? this.effect : overrideEffect;
+    var effect = typeof(overrideEffect) == 'undefined' ? this.effect : overrideEffect;
     if (!effect || !this._vertexBuffer)
     {
         return;
@@ -199,6 +208,7 @@ EveSpriteSet.prototype.Clear = function()
 EveSpriteSet.prototype.Add = function(pos, blinkRate, blinkPhase, minScale, maxScale, falloff, color)
 {
     var item = new EveSpriteSetItem();
+    item.display = true;
     item.position = vec3.create(pos);
     item.blinkRate = blinkRate;
     item.blinkPhase = blinkPhase;
@@ -223,6 +233,7 @@ EveSpriteSet.prototype.Add = function(pos, blinkRate, blinkPhase, minScale, maxS
  */
 function EveSpriteSetItem()
 {
+    this.display = true;
     this.name = '';
     this.position = vec3.create();
     this.blinkRate = 0;

--- a/src/eve/EveSpriteSet.js
+++ b/src/eve/EveSpriteSet.js
@@ -141,7 +141,7 @@ EveSpriteSet.prototype.GetBatches = function(mode, accumulator, perObjectData)
  */
 EveSpriteSet.prototype.Render = function(overrideEffect)
 {
-    var effect = typeof(overrideEffect) == 'undefined' ? this.effect : overrideEffect;
+    var effect = (!overrideEffect) ? this.effect : overrideEffect;
     if (!effect || !this._vertexBuffer)
     {
         return;

--- a/src/eve/EveSpriteSet.js
+++ b/src/eve/EveSpriteSet.js
@@ -1,3 +1,15 @@
+/**
+ * EveSpriteSet
+ * @property {string} name
+ * @property {Array.<EveSpriteSetItem>} sprites
+ * @property {Tw2Effect} effect
+ * @property {boolean} display
+ * @property {number} _time
+ * @property {WebGlBuffer} _vertexBuffer
+ * @property {WebGlBuffer} _indexBuffer
+ * @property {Tw2VertexDeclaration} _decl
+ * @constructor
+ */
 function EveSpriteSet()
 {
     this.name = '';
@@ -20,12 +32,18 @@ function EveSpriteSet()
     this._decl.RebuildHash();
 }
 
-EveSpriteSet.prototype.Initialize = function ()
+/**
+ * Initializes the sprite set
+ */
+EveSpriteSet.prototype.Initialize = function()
 {
     this.RebuildBuffers();
 };
 
-EveSpriteSet.prototype.RebuildBuffers = function ()
+/**
+ * Rebuilds the sprite set's buffers
+ */
+EveSpriteSet.prototype.RebuildBuffers = function()
 {
     var vertexSize = 13;
     var array = new Float32Array(this.sprites.length * 4 * vertexSize);
@@ -77,21 +95,35 @@ EveSpriteSet.prototype.RebuildBuffers = function ()
     this._indexBuffer.count = this.sprites.length * 6;
 };
 
+/**
+ * Sprite set render batch
+ * @inherits Tw2RenderBatch
+ * @constructor
+ */
 function EveSpriteSetBatch()
 {
     this._super.constructor.call(this);
     this.spriteSet = null;
 }
 
-EveSpriteSetBatch.prototype.Commit = function (overrideEffect)
+/**
+ * Commits the sprite set
+ * @param {Tw2Effect} overrideEffect
+ */
+EveSpriteSetBatch.prototype.Commit = function(overrideEffect)
 {
     this.spriteSet.Render(overrideEffect);
 };
 
 Inherit(EveSpriteSetBatch, Tw2RenderBatch);
 
-
-EveSpriteSet.prototype.GetBatches = function (mode, accumulator, perObjectData)
+/**
+ * Gets render batches
+ * @param {RenderMode} mode
+ * @param {Tw2BatchAccumulator} accumulator
+ * @param {Tw2PerObjectData} perObjectData
+ */
+EveSpriteSet.prototype.GetBatches = function(mode, accumulator, perObjectData)
 {
     if (this.display && mode == device.RM_ADDITIVE)
     {
@@ -103,9 +135,13 @@ EveSpriteSet.prototype.GetBatches = function (mode, accumulator, perObjectData)
     }
 };
 
-EveSpriteSet.prototype.Render = function (overrideEffect)
+/**
+ * Renders the sprite set
+ * @param {Tw2Effect} overrideEffect
+ */
+EveSpriteSet.prototype.Render = function(overrideEffect)
 {
-    var effect = typeof (overrideEffect) == 'undefined' ? this.effect : overrideEffect;
+    var effect = typeof(overrideEffect) == 'undefined' ? this.effect : overrideEffect;
     if (!effect || !this._vertexBuffer)
     {
         return;
@@ -132,17 +168,35 @@ EveSpriteSet.prototype.Render = function (overrideEffect)
     }
 };
 
-EveSpriteSet.prototype.Update = function (dt)
+/**
+ * Per frame update
+ * @param {number} dt - Delta time
+ */
+EveSpriteSet.prototype.Update = function(dt)
 {
     this._time += dt;
 };
 
-EveSpriteSet.prototype.Clear = function ()
+/**
+ * Clears the sprite set's sprites
+ */
+EveSpriteSet.prototype.Clear = function()
 {
     this.sprites = [];
 };
 
-EveSpriteSet.prototype.Add = function (pos, blinkRate, blinkPhase, minScale, maxScale, falloff, color)
+/**
+ * Adds a sprite set item to the sprite set
+ * @param {vec3} pos
+ * @param {number} blinkRate
+ * @param {number} blinkPhase
+ * @param {number} minScale
+ * @param {number} maxScale
+ * @param {number} falloff
+ * @param {quat4} color
+ * @constructor
+ */
+EveSpriteSet.prototype.Add = function(pos, blinkRate, blinkPhase, minScale, maxScale, falloff, color)
 {
     var item = new EveSpriteSetItem();
     item.position = vec3.create(pos);
@@ -151,20 +205,32 @@ EveSpriteSet.prototype.Add = function (pos, blinkRate, blinkPhase, minScale, max
     item.minScale = minScale;
     item.maxScale = maxScale;
     item.falloff = falloff;
-    item.color = color;
+    item.color = quat4.create(color);
     this.sprites[this.sprites.length] = item;
 };
 
+/**
+ * EveSpriteSetItem
+ * @property {string} name
+ * @property {vec3} position
+ * @property {number} blinkRate
+ * @property {number} minScale
+ * @property {number} falloff
+ * @property {quat4} color
+ * @property {number} boneIndex
+ * @property {number} groupIndex
+ * @constructor
+ */
 function EveSpriteSetItem()
 {
     this.name = '';
-    this.position = vec3.create([0, 0, 0]);
+    this.position = vec3.create();
     this.blinkRate = 0;
     this.blinkPhase = 0;
     this.minScale = 1;
     this.maxScale = 1;
     this.falloff = 0;
-    this.color = vec3.create([0, 0, 0]);
+    this.color = quat4.create();
     this.boneIndex = 0;
     this.groupIndex = -1;
 }


### PR DESCRIPTION
- Basic Documentation
- Fixed `EveSpriteSetItem` @property `color` which was set as a `vec3`, it is now a `quat4` and matches it's usage elsewhere (EveSof sets it as a `quat4` which is the type it is stored as in the Sof)
- Changed the type check for the `overrideEffect` argument
- Beautified
- Added @param display to `EveSpriteSetItem` @constructor
- Updated `EveSpriteSet` @prototype `RebuildBuffers` to allow individual `EveSpriteSetItem`s to have visibility controls