### PR TITLE
Fixes and Basic Docs EvePlaneSet, Updated EvePlaneSetItem

### DIFF
--- a/src/eve/EvePlaneSet.js
+++ b/src/eve/EvePlaneSet.js
@@ -49,9 +49,19 @@ EvePlaneSet.prototype.Initialize = function()
 EvePlaneSet.prototype.RebuildBuffers = function()
 {
     var vertexSize = 34;
-    var array = new Float32Array(this.planes.length * 4 * vertexSize);
+    var visibleItems = [];
+
+    for (var n = 0; n < this.planes.length; n++)
+    {
+        if (this.planes[n].display)
+        {
+            visibleItems.push(this.planes[n]);
+        }
+    }
+
+    var array = new Float32Array(visibleItems.length * 4 * vertexSize);
     var tempMat = mat4.create();
-    for (var i = 0; i < this.planes.length; ++i)
+    for (var i = 0; i < visibleItems.length; ++i)
     {
         var offset = i * 4 * vertexSize;
         array[offset + vertexSize - 2] = 0;
@@ -59,10 +69,10 @@ EvePlaneSet.prototype.RebuildBuffers = function()
         array[offset + 2 * vertexSize + vertexSize - 2] = 2;
         array[offset + 3 * vertexSize + vertexSize - 2] = 3;
 
-        var itemTransform = mat4.transpose(mat4.multiply(mat4.scale(mat4.identity(mat4.create()), this.planes[i].scaling), quat4.toMat4(this.planes[i].rotation, tempMat)));
-        itemTransform[12] = this.planes[i].position[0];
-        itemTransform[13] = this.planes[i].position[1];
-        itemTransform[14] = this.planes[i].position[2];
+        var itemTransform = mat4.transpose(mat4.multiply(mat4.scale(mat4.identity(mat4.create()), visibleItems[i].scaling), quat4.toMat4(visibleItems[i].rotation, tempMat)));
+        itemTransform[12] = visibleItems[i].position[0];
+        itemTransform[13] = visibleItems[i].position[1];
+        itemTransform[14] = visibleItems[i].position[2];
 
         for (var j = 0; j < 4; ++j)
         {
@@ -80,30 +90,30 @@ EvePlaneSet.prototype.RebuildBuffers = function()
             array[vtxOffset + 10] = itemTransform[10];
             array[vtxOffset + 11] = itemTransform[14];
 
-            array[vtxOffset + 12] = this.planes[i].color[0];
-            array[vtxOffset + 13] = this.planes[i].color[1];
-            array[vtxOffset + 14] = this.planes[i].color[2];
-            array[vtxOffset + 15] = this.planes[i].color[3];
+            array[vtxOffset + 12] = visibleItems[i].color[0];
+            array[vtxOffset + 13] = visibleItems[i].color[1];
+            array[vtxOffset + 14] = visibleItems[i].color[2];
+            array[vtxOffset + 15] = visibleItems[i].color[3];
 
-            array[vtxOffset + 16] = this.planes[i].layer1Transform[0];
-            array[vtxOffset + 17] = this.planes[i].layer1Transform[1];
-            array[vtxOffset + 18] = this.planes[i].layer1Transform[2];
-            array[vtxOffset + 19] = this.planes[i].layer1Transform[3];
+            array[vtxOffset + 16] = visibleItems[i].layer1Transform[0];
+            array[vtxOffset + 17] = visibleItems[i].layer1Transform[1];
+            array[vtxOffset + 18] = visibleItems[i].layer1Transform[2];
+            array[vtxOffset + 19] = visibleItems[i].layer1Transform[3];
 
-            array[vtxOffset + 20] = this.planes[i].layer2Transform[0];
-            array[vtxOffset + 21] = this.planes[i].layer2Transform[1];
-            array[vtxOffset + 22] = this.planes[i].layer2Transform[2];
-            array[vtxOffset + 23] = this.planes[i].layer2Transform[3];
+            array[vtxOffset + 20] = visibleItems[i].layer2Transform[0];
+            array[vtxOffset + 21] = visibleItems[i].layer2Transform[1];
+            array[vtxOffset + 22] = visibleItems[i].layer2Transform[2];
+            array[vtxOffset + 23] = visibleItems[i].layer2Transform[3];
 
-            array[vtxOffset + 24] = this.planes[i].layer1Scroll[0];
-            array[vtxOffset + 25] = this.planes[i].layer1Scroll[1];
-            array[vtxOffset + 26] = this.planes[i].layer1Scroll[2];
-            array[vtxOffset + 27] = this.planes[i].layer1Scroll[3];
+            array[vtxOffset + 24] = visibleItems[i].layer1Scroll[0];
+            array[vtxOffset + 25] = visibleItems[i].layer1Scroll[1];
+            array[vtxOffset + 26] = visibleItems[i].layer1Scroll[2];
+            array[vtxOffset + 27] = visibleItems[i].layer1Scroll[3];
 
-            array[vtxOffset + 28] = this.planes[i].layer2Scroll[0];
-            array[vtxOffset + 29] = this.planes[i].layer2Scroll[1];
-            array[vtxOffset + 30] = this.planes[i].layer2Scroll[2];
-            array[vtxOffset + 31] = this.planes[i].layer2Scroll[3];
+            array[vtxOffset + 28] = visibleItems[i].layer2Scroll[0];
+            array[vtxOffset + 29] = visibleItems[i].layer2Scroll[1];
+            array[vtxOffset + 30] = visibleItems[i].layer2Scroll[2];
+            array[vtxOffset + 31] = visibleItems[i].layer2Scroll[3];
 
             array[vtxOffset + 33] = this.boneIndex;
         }
@@ -113,10 +123,10 @@ EvePlaneSet.prototype.RebuildBuffers = function()
     device.gl.bufferData(device.gl.ARRAY_BUFFER, array, device.gl.STATIC_DRAW);
     device.gl.bindBuffer(device.gl.ARRAY_BUFFER, null);
 
-    var indexes = new Uint16Array(this.planes.length * 6);
-    for (i = 0; i < this.planes.length; ++i)
+    var indexes = new Uint16Array(visibleItems.length * 6);
+    for (i = 0; i < visibleItems.length; ++i)
     {
-        offset = i * 6;
+        var offset = i * 6;
         var vtxOffset = i * 4;
         indexes[offset] = vtxOffset;
         indexes[offset + 1] = vtxOffset + 2;
@@ -129,7 +139,7 @@ EvePlaneSet.prototype.RebuildBuffers = function()
     device.gl.bindBuffer(device.gl.ELEMENT_ARRAY_BUFFER, this._indexBuffer);
     device.gl.bufferData(device.gl.ELEMENT_ARRAY_BUFFER, indexes, device.gl.STATIC_DRAW);
     device.gl.bindBuffer(device.gl.ELEMENT_ARRAY_BUFFER, null);
-    this._indexBuffer.count = this.planes.length * 6;
+    this._indexBuffer.count = visibleItems.length * 6;
 };
 
 /**
@@ -243,6 +253,7 @@ EvePlaneSet.prototype.Clear = function()
  */
 function EvePlaneSetItem()
 {
+    this.display = true;
     this.name = '';
     this.position = vec3.create();
     this.scaling = vec3.create([1, 1, 1]);

--- a/src/eve/EvePlaneSet.js
+++ b/src/eve/EvePlaneSet.js
@@ -1,11 +1,23 @@
-﻿function EvePlaneSet()
+/**
+ * EvePlaneSet
+ * @property {String} name
+ * @property {Array.<EvePlaneSetItem>} planes
+ * @property {Tw2Effect} effect
+ * @property {boolean} display
+ * @property {boolean} hideOnLowQuality
+ * @property {number} _time
+ * @property {WebglBuffer} _vertexBuffer
+ * @property {WebglBuffer} _indexBuffer
+ * @property {Tw2VertexDeclaration} _decl
+ * @constructor
+ */
+function EvePlaneSet()
 {
     this.name = '';
     this.planes = [];
     this.effect = null;
     this.display = true;
     this.hideOnLowQuality = false;
-
     this._time = 0;
 
     this._vertexBuffer = null;
@@ -23,12 +35,18 @@
     this._decl.RebuildHash();
 }
 
-EvePlaneSet.prototype.Initialize = function ()
+/**
+ * Initializes the plane set
+ */
+EvePlaneSet.prototype.Initialize = function()
 {
     this.RebuildBuffers();
 };
 
-EvePlaneSet.prototype.RebuildBuffers = function ()
+/**
+ * Rebuilds the plane set's buffers
+ */
+EvePlaneSet.prototype.RebuildBuffers = function()
 {
     var vertexSize = 34;
     var array = new Float32Array(this.planes.length * 4 * vertexSize);
@@ -114,13 +132,23 @@ EvePlaneSet.prototype.RebuildBuffers = function ()
     this._indexBuffer.count = this.planes.length * 6;
 };
 
+/**
+ * Plane set render batch
+ * @inherits Tw2RenderBatch
+ * @constructor
+ */
 function EvePlaneSetBatch()
 {
     this._super.constructor.call(this);
     this.planeSet = null;
 }
 
-EvePlaneSetBatch.prototype.Commit = function (overrideEffect)
+/**
+ * Commits the plan set
+ * @param {Tw2Effect} [overrideEffect]
+ * @constructor
+ */
+EvePlaneSetBatch.prototype.Commit = function(overrideEffect)
 {
     this.planeSet.Render(overrideEffect);
 };
@@ -128,7 +156,13 @@ EvePlaneSetBatch.prototype.Commit = function (overrideEffect)
 Inherit(EvePlaneSetBatch, Tw2RenderBatch);
 
 
-EvePlaneSet.prototype.GetBatches = function (mode, accumulator, perObjectData)
+/**
+ * Gets the plane set's render batches
+ * @param {RenderMode} mode
+ * @param {Tw2BatchAccumulator} accumulator
+ * @param {Tw2PerObjectData} perObjectData
+ */
+EvePlaneSet.prototype.GetBatches = function(mode, accumulator, perObjectData)
 {
     if (this.display && mode == device.RM_ADDITIVE)
     {
@@ -140,9 +174,14 @@ EvePlaneSet.prototype.GetBatches = function (mode, accumulator, perObjectData)
     }
 };
 
-EvePlaneSet.prototype.Render = function (overrideEffect)
+/**
+ * Renders the plane set
+ * @param {Tw2Effect} [overrideEffect]
+ * @constructor
+ */
+EvePlaneSet.prototype.Render = function(overrideEffect)
 {
-    var effect = typeof (overrideEffect) == 'undefined' ? this.effect : overrideEffect;
+    var effect = (!overrideEffect) ? this.effect : overrideEffect;
     if (!effect || !this._vertexBuffer)
     {
         return;
@@ -169,27 +208,50 @@ EvePlaneSet.prototype.Render = function (overrideEffect)
     }
 };
 
-EvePlaneSet.prototype.Update = function (dt)
+/**
+ * Per frame update
+ * @param {number} dt - Delta Time
+ */
+EvePlaneSet.prototype.Update = function(dt)
 {
     this._time += dt;
 };
 
-EvePlaneSet.prototype.Clear = function ()
+/**
+ * Clears the plane set's plane items
+ */
+EvePlaneSet.prototype.Clear = function()
 {
     this.planes = [];
 };
 
+
+/**
+ * EvePlaneSetItem
+ * @property {string} name
+ * @property {vec3} position
+ * @property {vec3} scaling
+ * @property {quat4} rotation
+ * @property {quat4} color
+ * @property {quat4} layer1Transform
+ * @property {quat4} layer2Transform
+ * @property {quat4} layer1Scroll
+ * @property {quat4} layer2Scroll
+ * @property {number} boneIndex
+ * @property {number} groupIndex
+ * @constructor
+ */
 function EvePlaneSetItem()
 {
     this.name = '';
-    this.position = vec3.create([0, 0, 0]);
+    this.position = vec3.create();
     this.scaling = vec3.create([1, 1, 1]);
     this.rotation = quat4.create([0, 0, 0, 1]);
     this.color = quat4.create([1, 1, 1, 1]);
     this.layer1Transform = quat4.create([1, 1, 0, 0]);
     this.layer2Transform = quat4.create([1, 1, 0, 0]);
-    this.layer1Scroll = quat4.create([0, 0, 0, 0]);
-    this.layer2Scroll = quat4.create([0, 0, 0, 0]);
+    this.layer1Scroll = quat4.create();
+    this.layer2Scroll = quat4.create();
     this.boneIndex = 0;
     this.groupIndex = -1;
 }


### PR DESCRIPTION
- Basic Documentation
- changed type checks for `overrideEffect` @argument in the `Render` @prototype
- Removed unnecessary arrays from `quat4` and `vec3` creation
- Beautified
- Added @param `display` to `EvePlaneSetItem` @constructor
- Updated `EvePlaneSet` @prototype `RebuildBuffers` to allow individual `EvePlaneSetItems` to have visibility controls