### PR TITLE
Minor fixes, Updates and Basic Documentation EveTurretSet

### DIFF
--- a/src/eve/EveTurretSet.js
+++ b/src/eve/EveTurretSet.js
@@ -1,5 +1,6 @@
 /**
  * EveTurretData
+ * @property {String} name
  * @property {boolean} visible
  * @property {mat4} localTransform
  * @property {quat4} rotation
@@ -7,6 +8,7 @@
  */
 function EveTurretData()
 {
+    this.name = '';
     this.visible = true;
     this.localTransform = mat4.create();
     this.rotation = quat4.create();
@@ -206,8 +208,9 @@ EveTurretSet.prototype.InitializeFiringEffect = function()
  * Sets the local transform for a specific turret index
  * @param {number} index
  * @param {mat4} localTransform
+ * @param {String} locatorName
  */
-EveTurretSet.prototype.SetLocalTransform = function(index, localTransform)
+EveTurretSet.prototype.SetLocalTransform = function(index, localTransform, locatorName)
 {
     var transform = mat4.create(localTransform);
     vec3.normalize(transform.subarray(0, 3));
@@ -216,6 +219,7 @@ EveTurretSet.prototype.SetLocalTransform = function(index, localTransform)
     if (index >= this.turrets.length)
     {
         var data = new EveTurretData();
+        data.name = locatorName;
         data.localTransform.set(transform);
         this.turrets[index] = data;
     }

--- a/src/eve/EveTurretSet.js
+++ b/src/eve/EveTurretSet.js
@@ -477,10 +477,13 @@ EveTurretSet.prototype.Render = function(batch, overrideEffect)
     }
     for (; index < this.turrets.length; ++index)
     {
-        var isActive = this.state == this.STATE_FIRING && index == this._activeTurret;
-        if (batch.renderActive == isActive)
+        if (this.turrets[index].visible)
         {
-            this.geometryResource.RenderAreas(0, 0, 1, effect);
+            var isActive = this.state == this.STATE_FIRING && index == this._activeTurret;
+            if (batch.renderActive == isActive)
+            {
+                this.geometryResource.RenderAreas(0, 0, 1, effect);
+            }
         }
     }
 };

--- a/src/eve/EveTurretSet.js
+++ b/src/eve/EveTurretSet.js
@@ -1,3 +1,10 @@
+/**
+ * EveTurretData
+ * @property {boolean} visible
+ * @property {mat4} localTransform
+ * @property {quat4} rotation
+ * @constructor
+ */
 function EveTurretData()
 {
     this.visible = true;
@@ -5,29 +12,63 @@ function EveTurretData()
     this.rotation = quat4.create();
 }
 
+/**
+ * EveTurretSet
+ * @property {boolean} display
+ * @property {string} name
+ * @property {quat4} boundingSphere
+ * @property {number} bottomClipHeight
+ * @property {string} locatorName
+ * @property {Tw2Effect} turretEffect
+ * @property {vec3} targetPosition
+ * @property {number} sysBoneHeight
+ * @property {string} firingEffectResPath
+ * @property {EveTurretFiringFx} firingEffect
+ * @property {boolean} hasCyclingFiringPos
+ * @property {string} geometryResPath
+ * @property {Tw2GeometryRes} geometryResource
+ * @property {Tw2AnimationController} activeAnimation
+ * @property {Tw2AnimationController} inactiveAnimation
+ * @property {mat4} parentMatrix
+ * @property {Array.<EveTurretData>} turrets
+ * @property {number} STATE_INACTIVE
+ * @property {number} STATE_IDLE
+ * @property {number} STATE_FIRING
+ * @property {number} STATE_PACKING
+ * @property {number} STATE_UNPACKING
+ * @property {number} state
+
+ * @property {Tw2PerObjectData} _perObjectDataActive
+ * @property {Tw2PerObjectData} _perObjectDataInactive
+ * @property {Array.<string>} worldNames
+ * @property {number} _activeTurret
+ * @property {number} _recheckTimeLeft
+ * @property {number} _currentCyclingFiresPos
+ * @constructor
+ */
 function EveTurretSet()
 {
+    this.display = true;
     this.name = '';
-    this.boundingSphere = [0, 0, 0, 0];
+    this.boundingSphere = quat4.create();
     this.bottomClipHeight = 0;
     this.locatorName = '';
-    this.turretEffect = null;
-    this.geometryResPath = '';
     this.sysBoneHeight = 0;
+    
+    this.turrets = [];
+    this.turretEffect = null;
+    this.targetPosition = vec3.create();
     this.firingEffectResPath = '';
-    this.hasCyclingFiringPos = false;
-
     this.firingEffect = null;
     
-    this.display = true;
-    
+    this.hasCyclingFiringPos = false;
+    this.geometryResPath = '';
     this.geometryResource = null;
+
     this.activeAnimation = new Tw2AnimationController();
     this.inactiveAnimation = new Tw2AnimationController();
-
+    
     this.parentMatrix = mat4.identity(mat4.create());
-
-    this.turrets = [];
     
     this.STATE_INACTIVE = 0;
     this.STATE_IDLE = 1;
@@ -36,8 +77,6 @@ function EveTurretSet()
     this.STATE_UNPACKING = 4;
 
     this.state = this.STATE_IDLE;
-
-    this.targetPosition = vec3.create();
     
     this._perObjectDataActive = new Tw2PerObjectData();
     this._perObjectDataActive.perObjectVSData = new Tw2RawData();
@@ -66,17 +105,25 @@ function EveTurretSet()
     this._currentCyclingFiresPos = 0;
 }
 
+/**
+ * Bone Skeleton Names
+ * @type {string[]}
+ */
 EveTurretSet.positionBoneSkeletonNames = [
     "Pos_Fire01",
-	"Pos_Fire02",
-	"Pos_Fire03",
-	"Pos_Fire04",
-	"Pos_Fire05",
-	"Pos_Fire06",
-	"Pos_Fire07",
-	"Pos_Fire08"];
+    "Pos_Fire02",
+    "Pos_Fire03",
+    "Pos_Fire04",
+    "Pos_Fire05",
+    "Pos_Fire06",
+    "Pos_Fire07",
+    "Pos_Fire08"
+];
 
-EveTurretSet.prototype.Initialize = function ()
+/**
+ * Initializes the Turret Set
+ */
+EveTurretSet.prototype.Initialize = function()
 {
     if (this.turretEffect && this.geometryResPath != '')
     {
@@ -88,13 +135,20 @@ EveTurretSet.prototype.Initialize = function ()
             this.geometryResource.RegisterNotification(this);
         }
     }
-    if (this.firingEffectResPath != '') {
+    if (this.firingEffectResPath != '')
+    {
         var self = this;
-        resMan.GetObject(this.firingEffectResPath, function (object) { self.firingEffect = object; });
+        resMan.GetObject(this.firingEffectResPath, function(object)
+        {
+            self.firingEffect = object;
+        });
     }
 };
 
-EveTurretSet.prototype.RebuildCachedData = function (resource)
+/**
+ * Rebuilds the turret sets cached data
+ */
+EveTurretSet.prototype.RebuildCachedData = function()
 {
     var instancedElement = new Tw2VertexElement(Tw2VertexDeclaration.DECL_TEXCOORD, 1, device.gl.FLOAT, 2);
     for (var i = 0; i < this.geometryResource.meshes.length; ++i)
@@ -105,40 +159,55 @@ EveTurretSet.prototype.RebuildCachedData = function (resource)
     var self = this;
     switch (this.state)
     {
-    case this.STATE_INACTIVE:
-        this.activeAnimation.PlayAnimation("Inactive", true);
-        this.inactiveAnimation.PlayAnimation("Inactive", true);
-        break;
-    case this.STATE_IDLE:
-        this.activeAnimation.PlayAnimation("Active", true);
-        this.inactiveAnimation.PlayAnimation("Active", true);
-        break;
-    case this.STATE_FIRING:
-        this.activeAnimation.PlayAnimation("Fire", false, function () { self.activeAnimation.PlayAnimation("Active", true); });
-        this.inactiveAnimation.PlayAnimation("Active", true);
-        break;
-    case this.STATE_PACKING:
-        this.EnterStateIdle();
-        break;
-    case this.STATE_UNPACKING:
-        this.EnterStateDeactive();
-        break;
+        case this.STATE_INACTIVE:
+            this.activeAnimation.PlayAnimation("Inactive", true);
+            this.inactiveAnimation.PlayAnimation("Inactive", true);
+            break;
+        case this.STATE_IDLE:
+            this.activeAnimation.PlayAnimation("Active", true);
+            this.inactiveAnimation.PlayAnimation("Active", true);
+            break;
+        case this.STATE_FIRING:
+            this.activeAnimation.PlayAnimation("Fire", false, function()
+            {
+                self.activeAnimation.PlayAnimation("Active", true);
+            });
+            this.inactiveAnimation.PlayAnimation("Active", true);
+            break;
+        case this.STATE_PACKING:
+            this.EnterStateIdle();
+            break;
+        case this.STATE_UNPACKING:
+            this.EnterStateDeactive();
+            break;
     }
 };
 
-EveTurretSet.prototype.InitializeFiringEffect = function () {
-    if (!this.firingEffect) {
+/**
+ * Initializes turret set firing effect
+ */
+EveTurretSet.prototype.InitializeFiringEffect = function()
+{
+    if (!this.firingEffect)
+    {
         return;
     }
-    if (this.geometryResource && this.geometryResource.models.length) {
+    if (this.geometryResource && this.geometryResource.models.length)
+    {
         var model = this.geometryResource.models[0];
-        for (var i = 0; i < this.firingEffect.GetPerMuzzleEffectCount() ; ++i) {
+        for (var i = 0; i < this.firingEffect.GetPerMuzzleEffectCount(); ++i)
+        {
             this.firingEffect.SetMuzzleBoneID(i, model.FindBoneByName(EveTurretSet.positionBoneSkeletonNames[i]));
         }
     }
 };
 
-EveTurretSet.prototype.SetLocalTransform = function (index, localTransform)
+/**
+ * Sets the local transform for a specific turret index
+ * @param {number} index
+ * @param {mat4} localTransform
+ */
+EveTurretSet.prototype.SetLocalTransform = function(index, localTransform)
 {
     var transform = mat4.create(localTransform);
     vec3.normalize(transform.subarray(0, 3));
@@ -147,17 +216,18 @@ EveTurretSet.prototype.SetLocalTransform = function (index, localTransform)
     if (index >= this.turrets.length)
     {
         var data = new EveTurretData();
-        data.localTransform = transform;
+        data.localTransform.set(transform);
         this.turrets[index] = data;
     }
     else
     {
-        this.turrets[index].localTransform = transform;
+        this.turrets[index].localTransform.set(transform);
     }
     mat4toquat(this.turrets[index].localTransform, this.turrets[index].rotation);
 };
 
-function mat3x4toquat(mm, index, out, outIndex) {
+function mat3x4toquat(mm, index, out, outIndex)
+{
     index *= 12;
     outIndex *= 4;
     var m = mat3x4toquat._tempMat;
@@ -189,55 +259,64 @@ mat3x4toquat._tempMat = mat4.create();
 mat3x4toquat._tempQuat = quat4.create();
 
 
-function mat4toquat(m, out) {
+function mat4toquat(m, out)
+{
     out = out || quat4.create();
-	var trace = m[0] + m[5] + m[10] + 1.0;
-	if ( trace > 1.0) {
-		out[0] = ( m[6] - m[9] ) / ( 2.0 * Math.sqrt( trace ) );
-		out[1] = ( m[8] - m[2] ) / ( 2.0 * Math.sqrt( trace ) );
-		out[2] = ( m[1] - m[4] ) / ( 2.0 * Math.sqrt( trace ) );
-		out[3] = Math.sqrt(trace) / 2.0;
-		return out;
-	}
-	var maxi = 0;
-	var maxdiag = m[0];
-	for (var i = 1; i<3; i++)
-	{
-		if ( m[i * 4 + i] > maxdiag )
-		{
-			maxi = i;
-			maxdiag = m[i * 4 + i];
-		}
-	}
+    var trace = m[0] + m[5] + m[10] + 1.0;
+    if (trace > 1.0)
+    {
+        out[0] = (m[6] - m[9]) / (2.0 * Math.sqrt(trace));
+        out[1] = (m[8] - m[2]) / (2.0 * Math.sqrt(trace));
+        out[2] = (m[1] - m[4]) / (2.0 * Math.sqrt(trace));
+        out[3] = Math.sqrt(trace) / 2.0;
+        return out;
+    }
+    var maxi = 0;
+    var maxdiag = m[0];
+    for (var i = 1; i < 3; i++)
+    {
+        if (m[i * 4 + i] > maxdiag)
+        {
+            maxi = i;
+            maxdiag = m[i * 4 + i];
+        }
+    }
     var S;
-	switch( maxi )
-	{
-	case 0:
-		S = 2.0 * Math.sqrt( 1.0 + m[0] - m[5] - m[10] );
-		out[0] = 0.25 * S;
-		out[1] = ( m[1] + m[4] ) / S;
-		out[2] = ( m[2] + m[8] ) / S;
-		out[3] = ( m[6] - m[9] ) / S;
-		break;
-	case 1:
-		S = 2.0 * Math.sqrt( 1.0 + m[5] - m[0] - m[10] );
-		out[0] = ( m[1] + m[4] ) / S;
-		out[1] = 0.25 * S;
-		out[2] = ( m[6] + m[9] ) / S;
-		out[3] = ( m[8] - m[2] ) / S;
-		break;
-	case 2:
-		S = 2.0 * Math.sqrt( 1.0 + m[10] - m[0] - m[5] );
-		out[0] = ( m[2] + m[8] ) / S;
-		out[1] = ( m[6] + m[9] ) / S;
-		out[2] = 0.25 * S;
-		out[3] = ( m[1] - m[4] ) / S;
-		break;
-	}
-	return out;
+    switch (maxi)
+    {
+        case 0:
+            S = 2.0 * Math.sqrt(1.0 + m[0] - m[5] - m[10]);
+            out[0] = 0.25 * S;
+            out[1] = (m[1] + m[4]) / S;
+            out[2] = (m[2] + m[8]) / S;
+            out[3] = (m[6] - m[9]) / S;
+            break;
+        case 1:
+            S = 2.0 * Math.sqrt(1.0 + m[5] - m[0] - m[10]);
+            out[0] = (m[1] + m[4]) / S;
+            out[1] = 0.25 * S;
+            out[2] = (m[6] + m[9]) / S;
+            out[3] = (m[8] - m[2]) / S;
+            break;
+        case 2:
+            S = 2.0 * Math.sqrt(1.0 + m[10] - m[0] - m[5]);
+            out[0] = (m[2] + m[8]) / S;
+            out[1] = (m[6] + m[9]) / S;
+            out[2] = 0.25 * S;
+            out[3] = (m[1] - m[4]) / S;
+            break;
+    }
+    return out;
 }
 
-EveTurretSet.prototype._UpdatePerObjectData = function (perObjectData, transforms) {
+/**
+ * Updates per object data
+ * @param {Tw2PerObjectData} perObjectData
+ * @param transforms
+ * @private
+ */
+EveTurretSet.prototype._UpdatePerObjectData = function(perObjectData, transforms)
+{
     mat4.transpose(this.parentMatrix, perObjectData.Get('shipMatrix'));
     var transformCount = transforms.length / 12;
     perObjectData.Get('turretSetData')[0] = transformCount;
@@ -247,7 +326,8 @@ EveTurretSet.prototype._UpdatePerObjectData = function (perObjectData, transform
     var pose = perObjectData.Get('turretPoseTransAndRot');
     for (var i = 0; i < this.turrets.length; ++i)
     {
-        for (var j = 0; j < transformCount; ++j) {
+        for (var j = 0; j < transformCount; ++j)
+        {
             pose[(i * transformCount + j) * 2 * 4] = transforms[j * 12 + 3];
             pose[(i * transformCount + j) * 2 * 4 + 1] = transforms[j * 12 + 7];
             pose[(i * transformCount + j) * 2 * 4 + 2] = transforms[j * 12 + 11];
@@ -265,7 +345,14 @@ EveTurretSet.prototype._UpdatePerObjectData = function (perObjectData, transform
     }
 };
 
-EveTurretSet.prototype.GetBatches = function (mode, accumulator, perObjectData)
+/**
+ * Gets turret set render batches
+ * @param {RenderMode} mode
+ * @param {Tw2BatchAccumulator} accumulator
+ * @param {Tw2PerObjectData} perObjectData
+ * @returns {boolean}
+ */
+EveTurretSet.prototype.GetBatches = function(mode, accumulator, perObjectData)
 {
     if (!this.turretEffect || this.geometryResource == null || !this.display)
     {
@@ -280,7 +367,7 @@ EveTurretSet.prototype.GetBatches = function (mode, accumulator, perObjectData)
         }
         this._UpdatePerObjectData(this._perObjectDataInactive.perObjectVSData, transforms);
         this._perObjectDataInactive.perObjectPSData = perObjectData.perObjectPSData;
-    
+
         var batch = new Tw2ForwardingRenderBatch();
         batch.renderMode = mode;
         batch.renderActive = false;
@@ -288,9 +375,11 @@ EveTurretSet.prototype.GetBatches = function (mode, accumulator, perObjectData)
         batch.geometryProvider = this;
         accumulator.Commit(batch);
 
-        if (this.state == this.STATE_FIRING) {
+        if (this.state == this.STATE_FIRING)
+        {
             transforms = this.activeAnimation.GetBoneMatrixes(0);
-            if (transforms.length == 0) {
+            if (transforms.length == 0)
+            {
                 return true;
             }
             this._UpdatePerObjectData(this._perObjectDataActive.perObjectVSData, transforms);
@@ -310,35 +399,49 @@ EveTurretSet.prototype.GetBatches = function (mode, accumulator, perObjectData)
     return true;
 };
 
-EveTurretSet.prototype.Update = function (dt, parentMatrix)
+/**
+ * Per frame update
+ * @param {number} dt - Delta Time
+ * @param {mat4} parentMatrix
+ */
+EveTurretSet.prototype.Update = function(dt, parentMatrix)
 {
-    if (this.turretEffect) {
+    if (this.turretEffect)
+    {
         this.activeAnimation.Update(dt);
         this.inactiveAnimation.Update(dt);
     }
     mat4.set(parentMatrix, this.parentMatrix);
     if (this.firingEffect)
     {
-        if (this._activeTurret != -1) {
-            if (this.firingEffect.isLoopFiring) {
-                if (this.state == this.STATE_FIRING) {
+        if (this._activeTurret != -1)
+        {
+            if (this.firingEffect.isLoopFiring)
+            {
+                if (this.state == this.STATE_FIRING)
+                {
                     this._recheckTimeLeft -= dt;
-                    if (this._recheckTimeLeft <= 0) {
+                    if (this._recheckTimeLeft <= 0)
+                    {
                         this._DoStartFiring();
                     }
                 }
             }
             var i;
-            if (this.activeAnimation.models.length) {
+            if (this.activeAnimation.models.length)
+            {
                 var bones = this.activeAnimation.models[0].bonesByName;
-                for (i = 0; i < this.firingEffect.GetPerMuzzleEffectCount() ; ++i) {
+                for (i = 0; i < this.firingEffect.GetPerMuzzleEffectCount(); ++i)
+                {
                     var transform = bones[EveTurretSet.positionBoneSkeletonNames[i]].worldTransform;
                     var out = this.firingEffect.GetMuzzleTransform(i);
                     mat4.multiply(parentMatrix, mat4.multiply(this.turrets[this._activeTurret].localTransform, transform, out), out);
                 }
             }
-            else {
-                for (i = 0; i < this.firingEffect.GetPerMuzzleEffectCount() ; ++i) {
+            else
+            {
+                for (i = 0; i < this.firingEffect.GetPerMuzzleEffectCount(); ++i)
+                {
                     mat4.multiply(parentMatrix, this.turrets[this._activeTurret].localTransform, this.firingEffect.GetMuzzleTransform(i));
                 }
             }
@@ -349,14 +452,19 @@ EveTurretSet.prototype.Update = function (dt, parentMatrix)
     }
 };
 
-EveTurretSet.prototype.Render = function (batch, overrideEffect)
+/**
+ * Renders the turret set
+ * @param batch
+ * @param {Tw2Effect} overrideEffect
+ */
+EveTurretSet.prototype.Render = function(batch, overrideEffect)
 {
-    var effect = typeof (overrideEffect) == 'undefined' ? this.turretEffect : overrideEffect;
+    var effect = (!overrideEffect) ? this.turretEffect : overrideEffect;
     var index = 0;
-    var customSetter = function(el) 
-    { 
-        device.gl.disableVertexAttribArray(el.location); 
-        device.gl.vertexAttrib2f(el.location, index, index); 
+    var customSetter = function(el)
+    {
+        device.gl.disableVertexAttribArray(el.location);
+        device.gl.vertexAttrib2f(el.location, index, index);
     };
     for (var i = 0; i < this.geometryResource.meshes.length; ++i)
     {
@@ -366,72 +474,111 @@ EveTurretSet.prototype.Render = function (batch, overrideEffect)
     for (; index < this.turrets.length; ++index)
     {
         var isActive = this.state == this.STATE_FIRING && index == this._activeTurret;
-        if (batch.renderActive == isActive) {
+        if (batch.renderActive == isActive)
+        {
             this.geometryResource.RenderAreas(0, 0, 1, effect);
         }
     }
 };
 
-EveTurretSet.prototype.EnterStateDeactive = function ()
+/**
+ * Animation helper function for deactivating a turret set
+ */
+EveTurretSet.prototype.EnterStateDeactive = function()
 {
     if (this.state == this.STATE_INACTIVE || this.state == this.STATE_PACKING)
     {
         return;
     }
     var self = this;
-    if (this.turretEffect) {
+    if (this.turretEffect)
+    {
         this.activeAnimation.StopAllAnimations();
         this.inactiveAnimation.StopAllAnimations();
-        this.activeAnimation.PlayAnimation("Pack", false, function () { self.state = self.STATE_INACTIVE; self.activeAnimation.PlayAnimation("Inactive", true); });
-        this.inactiveAnimation.PlayAnimation("Pack", false, function () { self.state = self.STATE_INACTIVE; self.inactiveAnimation.PlayAnimation("Inactive", true); });
+        this.activeAnimation.PlayAnimation("Pack", false, function()
+        {
+            self.state = self.STATE_INACTIVE;
+            self.activeAnimation.PlayAnimation("Inactive", true);
+        });
+        this.inactiveAnimation.PlayAnimation("Pack", false, function()
+        {
+            self.state = self.STATE_INACTIVE;
+            self.inactiveAnimation.PlayAnimation("Inactive", true);
+        });
         this.state = this.STATE_PACKING;
     }
-    else {
+    else
+    {
         this.state = self.STATE_INACTIVE;
     }
     this._activeTurret = -1;
-    if (this.firingEffect) {
+    if (this.firingEffect)
+    {
         this.firingEffect.StopFiring();
     }
 };
 
-EveTurretSet.prototype.EnterStateIdle = function ()
+/**
+ * Animation helper function for putting a turret set into idle state
+ */
+EveTurretSet.prototype.EnterStateIdle = function()
 {
+    var self = this;
     if (this.state == this.STATE_IDLE || this.state == this.STATE_UNPACKING)
     {
         return;
     }
-    if (this.turretEffect) {
+    if (this.turretEffect)
+    {
         this.activeAnimation.StopAllAnimations();
         this.inactiveAnimation.StopAllAnimations();
-        if (this.state == this.STATE_FIRING) {
+        if (this.state == this.STATE_FIRING)
+        {
             this.activeAnimation.PlayAnimation("Active", true);
             this.inactiveAnimation.PlayAnimation("Active", true);
         }
-        else {
-            var self = this;
-            this.activeAnimation.PlayAnimation("Deploy", false, function () { self.state = self.STATE_IDLE; self.activeAnimation.PlayAnimation("Active", true); });
-            this.inactiveAnimation.PlayAnimation("Deploy", false, function () { self.state = self.STATE_IDLE; self.inactiveAnimation.PlayAnimation("Active", true); });
+        else
+        {
+            this.activeAnimation.PlayAnimation("Deploy", false, function()
+            {
+                self.state = self.STATE_IDLE;
+                self.activeAnimation.PlayAnimation("Active", true);
+            });
+            this.inactiveAnimation.PlayAnimation("Deploy", false, function()
+            {
+                self.state = self.STATE_IDLE;
+                self.inactiveAnimation.PlayAnimation("Active", true);
+            });
         }
         this.state = this.STATE_UNPACKING;
     }
-    else {
+    else
+    {
         this.state = self.STATE_IDLE;
     }
     this._activeTurret = -1;
-    if (this.firingEffect) {
+    if (this.firingEffect)
+    {
         this.firingEffect.StopFiring();
     }
 };
 
-EveTurretSet.prototype.EnterStateFiring = function ()
+/**
+ * Animation helper function for putting a turret set into a firing state
+ */
+EveTurretSet.prototype.EnterStateFiring = function()
 {
+    var self = this;
+    
     if (!this.turretEffect || this.state == this.STATE_FIRING)
     {
         this._DoStartFiring();
-        if (this.turretEffect) {
-            var self = this;
-            this.activeAnimation.PlayAnimation("Fire", false, function () { self.activeAnimation.PlayAnimation("Active", true); });
+        if (this.turretEffect)
+        {
+            this.activeAnimation.PlayAnimation("Fire", false, function()
+            {
+                self.activeAnimation.PlayAnimation("Active", true);
+            });
         }
         return;
     }
@@ -439,32 +586,56 @@ EveTurretSet.prototype.EnterStateFiring = function ()
     this.inactiveAnimation.StopAllAnimations();
     if (this.state == this.STATE_INACTIVE)
     {
-        var self = this;
-        this.activeAnimation.PlayAnimation("Deploy", false, function () { self._DoStartFiring(); self.activeAnimation.PlayAnimation("Fire", false, function () { self.activeAnimation.PlayAnimation("Active", true); }); });
-        this.inactiveAnimation.PlayAnimation("Deploy", false, function () { self.inactiveAnimation.PlayAnimation("Active", true); });
+        this.activeAnimation.PlayAnimation("Deploy", false, function()
+        {
+            self._DoStartFiring();
+            self.activeAnimation.PlayAnimation("Fire", false, function()
+            {
+                self.activeAnimation.PlayAnimation("Active", true);
+            });
+        });
+        this.inactiveAnimation.PlayAnimation("Deploy", false, function()
+        {
+            self.inactiveAnimation.PlayAnimation("Active", true);
+        });
         this.state = this.STATE_UNPACKING;
     }
     else
     {
         this._DoStartFiring();
-        var self = this;
-        this.activeAnimation.PlayAnimation("Fire", false, function () { self.activeAnimation.PlayAnimation("Active", true); });
+        this.activeAnimation.PlayAnimation("Fire", false, function()
+        {
+            self.activeAnimation.PlayAnimation("Active", true);
+        });
         this.inactiveAnimation.PlayAnimation("Active", true);
     }
 };
 
-EveTurretSet.prototype.UpdateViewDependentData = function () {
-    if (this.firingEffect) {
+/**
+ * Updates view dependent data
+ * @constructor
+ */
+EveTurretSet.prototype.UpdateViewDependentData = function()
+{
+    if (this.firingEffect)
+    {
         this.firingEffect.UpdateViewDependentData();
     }
 }
 
-EveTurretSet.prototype._DoStartFiring = function () {
-    if (this.hasCyclingFiringPos) {
+/**
+ * Animation helper function for turret firing
+ * @private
+ */
+EveTurretSet.prototype._DoStartFiring = function()
+{
+    if (this.hasCyclingFiringPos)
+    {
         this._currentCyclingFiresPos = 1 - this._currentCyclingFiresPos;
     }
     var turret = this.GetClosestTurret();
-    if (this.firingEffect) {
+    if (this.firingEffect)
+    {
         this.firingEffect.PrepareFiring(0, this.hasCyclingFiringPos ? this._currentCyclingFiresPos : -1);
     }
     this._activeTurret = turret;
@@ -475,13 +646,19 @@ EveTurretSet.prototype._DoStartFiring = function () {
 EveTurretSet._tempVec3 = [vec3.create(), vec3.create()];
 EveTurretSet._tempQuat4 = [quat4.create(), quat4.create()];
 
-EveTurretSet.prototype.GetClosestTurret = function () {
+/**
+ * Helper function for finding out what turret should be firing
+ * @returns {number}
+ */
+EveTurretSet.prototype.GetClosestTurret = function()
+{
     var closestTurret = -1;
     var closestAngle = -2;
     var nrmToTarget = EveTurretSet._tempVec3[0];
     var nrmUp = EveTurretSet._tempQuat4[0];
     var turretPosition = EveTurretSet._tempQuat4[1];
-    for (var i = 0; i < this.turrets.length; ++i) {
+    for (var i = 0; i < this.turrets.length; ++i)
+    {
         turretPosition[0] = this.turrets[i].localTransform[12];
         turretPosition[1] = this.turrets[i].localTransform[13];
         turretPosition[2] = this.turrets[i].localTransform[14];
@@ -495,7 +672,8 @@ EveTurretSet.prototype.GetClosestTurret = function () {
         mat4.multiplyVec4(this.turrets[i].localTransform, nrmUp);
         mat4.multiplyVec4(this.parentMatrix, nrmUp);
         var angle = vec3.dot(nrmUp, nrmToTarget);
-        if (angle > closestAngle) {
+        if (angle > closestAngle)
+        {
             closestTurret = i;
             closestAngle = angle;
         }


### PR DESCRIPTION
- Basic Documentation
- changed @property `boundingSphere` so that it's created with `quat4.create` 
- Added `.set` method to `Float32Array`s that weren't using them
- changed @type checking on `overrideEffect` @argument 
- Fixed an occurrence where `var self = this` was requested outside of the scope it was defined
- Removed multiple `var self = this` occurrences in a @prototype and replaced with one
- Updated the @prototype `SetLocalTransform` so that it can assign locator names to individual turrets
- Updated the @prototype `Render` so that the `visible` @property on `EveTurretSet` turrets works
- Beautified

