### PR TITLE
Added customisable reflection maps for EveSpaceScene

### DIFF
--- a/src/eve/EveSpaceScene.js
+++ b/src/eve/EveSpaceScene.js
@@ -101,6 +101,15 @@ EveSpaceScene.prototype.Initialize = function ()
     }
 };
 
+EveSpaceScene.prototype.SetEnvMapReflection = function(path)
+{
+    this.envMapResPath = path;
+    if (this.envMapResPath != '')
+    {
+        this.envMapRes = resMan.GetResources ( path )
+    }
+};
+
 EveSpaceScene.prototype.SetEnvMapPath = function (index, path)
 {
     switch (index)


### PR DESCRIPTION
- Added `SetEnvMapReflection` prototype which allows for custom environment reflection maps on space object
- For some reason it is not included in the `SetEnvMapPath` (their indexes are all off by one) but haven't changed for compatibility