### PR TITLE
Basic Documentation and Display Options for EveSpaceObject

### DIFF
--- a/src/eve/EveSpaceObject.js
+++ b/src/eve/EveSpaceObject.js
@@ -1,57 +1,103 @@
+/**
+ * EveSpaceObject
+ * @parameter {String} name
+ * @parameter {Number} lod
+ * @parameter {Tw2Mesh} mesh
+ * @parameter {Array.<EveLocator>} locators
+ * @parameter {Array.<EveSpriteSet>} spriteSets
+ * @parameter {Array.<EveTurretSet>} turretSets
+ * @parameter {Array.<EveSpaceObjectDecal>} decals
+ * @parameter {Array.<EveSpotlightSet>} spotlightSets
+ * @parameter {Array.<EvePlaneSet>} planeSets
+ * @parameter {Array.<Tw2CurveSet>} curveSets
+ * @parameter {Array.<EveCurveLineSet>} lineSets
+ * @parameter {Array.<EveMeshOverlayEffect>} overlayEffects
+ * @parameter {Array.<{}>} children
+ * @parameter {vec3} boundingSphereCenter
+ * @parameter {Number} boundingSphereRadius
+ * @parameter {vec3} shapeEllipsoidRadius
+ * @parameter {vec3} shapeEllipsoidCenter
+ * @parameter {mat4} transform
+ * @parameter {Tw2AnimationController} animation
+ * @parameter {boolean} display - Toggles rendering of the whole space object
+ * @parameter {boolean} displayMesh - Toggles mesh rendering
+ * @parameter {boolean} displayChildren - toggles rendering of children
+ * @parameter {boolean} displaySprites - Toggles sprite set rendering
+ * @parameter {boolean} displayDecals - Toggles decal rendering
+ * @parameter {boolean} displaySpotlights - Toggles spotlight set rendering
+ * @parameter {boolean} displayPlanes - toggles plane set rendering
+ * @parameter {boolean} displayLines - toggles line set rendering
+ * @parameter {boolean} displayOverlays - toggles overlay effect rendering
+ * @parameter {vec3} _tempVec
+ * @parameter {Tw2PerObjectData} _perObjectData
+ * @constructor
+ */
 function EveSpaceObject()
 {
-	this.name = '';
-	this.mesh = null;
-	this.spriteSets = [];
-	this.boundingSphereCenter = vec3.create();
-	this.boundingSphereRadius = 0;
-	this.locators = [];
-	this.turretSets = [];
-	this.decals = [];
-	this.spotlightSets = [];
-	this.planeSets = [];
-	this.curveSets = [];
-    this.overlayEffects = [];
+    this.name = '';
+    this.lod = 3;
+    this.mesh = null;
+    this.locators = [];
 
+    this.spriteSets = [];
+    this.turretSets = [];
+    this.decals = [];
+    this.spotlightSets = [];
+    this.planeSets = [];
+    this.curveSets = [];
+    this.lineSets = [];
+    this.overlayEffects = [];
+    this.children = [];
+
+    this.boundingSphereCenter = vec3.create();
+    this.boundingSphereRadius = 0;
     this.shapeEllipsoidRadius = vec3.create();
     this.shapeEllipsoidCenter = vec3.create();
 
-	this.transform = mat4.create();
-	mat4.identity(this.transform);
-	
-	this.children = [];
-	
-	this._perObjectData = new Tw2PerObjectData();
-	this._perObjectData.perObjectVSData = new Tw2RawData();
-	this._perObjectData.perObjectVSData.Declare('WorldMat', 16);
-	this._perObjectData.perObjectVSData.Declare('WorldMatLast', 16);
-	this._perObjectData.perObjectVSData.Declare('Shipdata', 4);
-	this._perObjectData.perObjectVSData.Declare('Clipdata1', 4);
-	this._perObjectData.perObjectVSData.Declare('EllipsoidRadii', 4);
-	this._perObjectData.perObjectVSData.Declare('EllipsoidCenter', 4);
-	this._perObjectData.perObjectVSData.Declare('JointMat', 696);
-	this._perObjectData.perObjectVSData.Create();
-	
-	this._perObjectData.perObjectPSData = new Tw2RawData();
-	this._perObjectData.perObjectPSData.Declare('Shipdata', 4);
-	this._perObjectData.perObjectPSData.Declare('Clipdata1', 4);
-	this._perObjectData.perObjectPSData.Declare('Clipdata2', 4);
-	this._perObjectData.perObjectPSData.Declare('ShLighting', 4 * 7);
-	this._perObjectData.perObjectPSData.Declare('customMaskMatrix', 16);
-	this._perObjectData.perObjectPSData.Create();
+    this.transform = mat4.identity(mat4.create());
+    this.animation = new Tw2AnimationController();
 
-	this._perObjectData.perObjectVSData.Get('Shipdata')[1] = 1;
-	this._perObjectData.perObjectPSData.Get('Shipdata')[1] = 1;
-	this._perObjectData.perObjectVSData.Get('Shipdata')[3] = -10;
-	this._perObjectData.perObjectPSData.Get('Shipdata')[3] = 1;
+    this.display = true;
+    this.displayMesh = true;
+    this.displayChildren = true;
+    this.displayPlanes = true;
+    this.displaySpotlights = true;
+    this.displayDecals = true;
+    this.displaySprites = true;
+    this.displayOverlays = true;
+    this.displayLines = true;
+    
+    this._tempVec = vec3.create();
 
-	this.animation = new Tw2AnimationController();
+    this._perObjectData = new Tw2PerObjectData();
+    this._perObjectData.perObjectVSData = new Tw2RawData();
+    this._perObjectData.perObjectVSData.Declare('WorldMat', 16);
+    this._perObjectData.perObjectVSData.Declare('WorldMatLast', 16);
+    this._perObjectData.perObjectVSData.Declare('Shipdata', 4);
+    this._perObjectData.perObjectVSData.Declare('Clipdata1', 4);
+    this._perObjectData.perObjectVSData.Declare('EllipsoidRadii', 4);
+    this._perObjectData.perObjectVSData.Declare('EllipsoidCenter', 4);
+    this._perObjectData.perObjectVSData.Declare('JointMat', 696);
+    this._perObjectData.perObjectVSData.Create();
 
-	this.lod = 3;
-	this._tempVec = vec3.create();
+    this._perObjectData.perObjectPSData = new Tw2RawData();
+    this._perObjectData.perObjectPSData.Declare('Shipdata', 4);
+    this._perObjectData.perObjectPSData.Declare('Clipdata1', 4);
+    this._perObjectData.perObjectPSData.Declare('Clipdata2', 4);
+    this._perObjectData.perObjectPSData.Declare('ShLighting', 4 * 7);
+    this._perObjectData.perObjectPSData.Declare('customMaskMatrix', 16);
+    this._perObjectData.perObjectPSData.Create();
+
+    this._perObjectData.perObjectVSData.Get('Shipdata')[1] = 1;
+    this._perObjectData.perObjectPSData.Get('Shipdata')[1] = 1;
+    this._perObjectData.perObjectVSData.Get('Shipdata')[3] = -10;
+    this._perObjectData.perObjectPSData.Get('Shipdata')[3] = 1;
 }
 
-EveSpaceObject.prototype.Initialize = function ()
+/**
+ * Initializes the EveSpaceObject
+ */
+EveSpaceObject.prototype.Initialize = function()
 {
     if (this.mesh)
     {
@@ -63,12 +109,19 @@ EveSpaceObject.prototype.Initialize = function ()
     }
 };
 
-EveSpaceObject.prototype.ResetLod = function ()
+/**
+ * Resets the lod
+ */
+EveSpaceObject.prototype.ResetLod = function()
 {
     this.lod = 3;
 }
 
-EveSpaceObject.prototype.UpdateLod = function (frustum)
+/**
+ * Updates the lod
+ * @param {Tw2Frustum} frustum
+ */
+EveSpaceObject.prototype.UpdateLod = function(frustum)
 {
     var center = mat4.multiplyVec3(this.transform, this.boundingSphereCenter, this._tempVec);
 
@@ -89,17 +142,22 @@ EveSpaceObject.prototype.UpdateLod = function (frustum)
     }
 }
 
-EveSpaceObject.prototype.UpdateViewDependentData = function ()
+/**
+ * A Per frame function that updates view dependent data
+ */
+EveSpaceObject.prototype.UpdateViewDependentData = function()
 {
     for (var i = 0; i < this.children.length; ++i)
     {
         this.children[i].UpdateViewDependentData(this.transform);
     }
+
     mat4.transpose(this.transform, this._perObjectData.perObjectVSData.Get('WorldMat'));
     mat4.transpose(this.transform, this._perObjectData.perObjectVSData.Get('WorldMatLast'));
     var center = this._perObjectData.perObjectVSData.Get('EllipsoidCenter');
     var radii = this._perObjectData.perObjectVSData.Get('EllipsoidRadii');
-    if (this.shapeEllipsoidRadius[0] > 0) {
+    if (this.shapeEllipsoidRadius[0] > 0)
+    {
         center[0] = this.shapeEllipsoidCenter[0];
         center[1] = this.shapeEllipsoidCenter[1];
         center[2] = this.shapeEllipsoidCenter[2];
@@ -107,74 +165,132 @@ EveSpaceObject.prototype.UpdateViewDependentData = function ()
         radii[1] = this.shapeEllipsoidRadius[1];
         radii[2] = this.shapeEllipsoidRadius[2];
     }
-    else if (this.mesh && this.mesh.geometryResource && this.mesh.geometryResource.IsGood()) {
+    else if (this.mesh && this.mesh.geometryResource && this.mesh.geometryResource.IsGood())
+    {
         vec3.subtract(this.mesh.geometryResource.maxBounds, this.mesh.geometryResource.minBounds, center);
         vec3.scale(center, 0.5 * 1.732050807);
         vec3.add(this.mesh.geometryResource.maxBounds, this.mesh.geometryResource.minBounds, radii);
         vec3.scale(radii, 0.5);
     }
+
     if (this.animation.animations.length)
     {
         this._perObjectData.perObjectVSData.Set('JointMat', this.animation.GetBoneMatrixes(0));
     }
+
+    for (var s = 0; s < this.lineSets.length; ++s)
+    {
+        this.lineSets[s].UpdateViewDependentData(this.transform);
+    }
 }
 
-EveSpaceObject.prototype.GetBatches = function (mode, accumulator)
+/**
+ * Gets line render batches
+ * @param {RenderMode} mode
+ * @param {Tw2BatchAccumulator} accumulator
+ */
+EveSpaceObject.prototype.GetLineBatches = function(mode, accumulator)
 {
-    if (this.mesh != null && this.lod > 0)
+    for (var i = 0; i < this.lineSets.length; ++i)
     {
-        this.mesh.GetBatches(mode, accumulator, this._perObjectData);
+        this.lineSets[i].GetBatches(mode, accumulator);
     }
+}
 
-    var i;
-    if (this.lod > 1)
+/**
+ * Gets render batches
+ * @param {RenderMode} mode
+ * @param {Tw2BatchAccumulator} accumulator
+ */
+EveSpaceObject.prototype.GetBatches = function(mode, accumulator)
+{
+    if (this.display)
     {
-        for (i = 0; i < this.spriteSets.length; ++i)
+        if (this.displayMesh && this.mesh != null && this.lod > 0)
         {
-            this.spriteSets[i].GetBatches(mode, accumulator, this._perObjectData);
+            this.mesh.GetBatches(mode, accumulator, this._perObjectData);
         }
-        for (i = 0; i < this.spotlightSets.length; ++i)
+
+        if (this.lod > 1)
         {
-            this.spotlightSets[i].GetBatches(mode, accumulator, this._perObjectData);
-        }
-        for (i = 0; i < this.planeSets.length; ++i)
-        {
-            this.planeSets[i].GetBatches(mode, accumulator, this._perObjectData);
-        }
-        for (i = 0; i < this.decals.length; ++i)
-        {
-            this.decals[i].GetBatches(mode, accumulator, this._perObjectData);
-        }
-    }
-    for (i = 0; i < this.children.length; ++i)
-    {
-        this.children[i].GetBatches(mode, accumulator, this._perObjectData);
-    }
-    if (this.mesh && this.mesh.geometryResource && this.mesh.geometryResource.IsGood())
-    {
-        for (i = 0; i < this.overlayEffects.length; ++i)
-        {
-            var effects = this.overlayEffects[i].GetEffects(mode);
-            if (effects)
+            var i;
+
+            if (this.displaySprites)
             {
-                for (var j = 0; j < effects.length; ++j)
+                for (i = 0; i < this.spriteSets.length; ++i)
                 {
-                    var batch = new Tw2GeometryBatch();
-                    batch.renderMode = mode;
-                    batch.perObjectData = this._perObjectData;
-                    batch.geometryRes = this.mesh.geometryResource;
-                    batch.meshIx = this.mesh.meshIndex;
-                    batch.start = 0;
-                    batch.count = this.mesh.geometryResource.meshes[this.mesh.meshIndex].areas.length;
-                    batch.effect = effects[j];
-                    accumulator.Commit(batch);
+                    this.spriteSets[i].GetBatches(mode, accumulator, this._perObjectData);
+                }
+            }
+
+            if (this.displaySpotlights)
+            {
+                for (i = 0; i < this.spotlightSets.length; ++i)
+                {
+                    this.spotlightSets[i].GetBatches(mode, accumulator, this._perObjectData);
+                }
+            }
+
+            if (this.displayPlanes)
+            {
+                for (i = 0; i < this.planeSets.length; ++i)
+                {
+                    this.planeSets[i].GetBatches(mode, accumulator, this._perObjectData);
+                }
+            }
+
+            if (this.displayDecals)
+            {
+                for (i = 0; i < this.decals.length; ++i)
+                {
+                    this.decals[i].GetBatches(mode, accumulator, this._perObjectData);
+                }
+            }
+
+            if (this.displayLines)
+            {
+                this.GetLineBatches(mode, accumulator);
+            }
+        }
+
+        if (this.displayChildren)
+        {
+            for (i = 0; i < this.children.length; ++i)
+            {
+                this.children[i].GetBatches(mode, accumulator, this._perObjectData);
+            }
+        }
+
+        if (this.displayOverlays && this.mesh && this.mesh.geometryResource && this.mesh.geometryResource.IsGood())
+        {
+            for (i = 0; i < this.overlayEffects.length; ++i)
+            {
+                var effects = this.overlayEffects[i].GetEffects(mode);
+                if (effects)
+                {
+                    for (var j = 0; j < effects.length; ++j)
+                    {
+                        var batch = new Tw2GeometryBatch();
+                        batch.renderMode = mode;
+                        batch.perObjectData = this._perObjectData;
+                        batch.geometryRes = this.mesh.geometryResource;
+                        batch.meshIx = this.mesh.meshIndex;
+                        batch.start = 0;
+                        batch.count = this.mesh.geometryResource.meshes[this.mesh.meshIndex].areas.length;
+                        batch.effect = effects[j];
+                        accumulator.Commit(batch);
+                    }
                 }
             }
         }
     }
 };
 
-EveSpaceObject.prototype.Update = function (dt)
+/**
+ * Per frame update
+ * @param {Number} dt - delta time
+ */
+EveSpaceObject.prototype.Update = function(dt)
 {
     if (this.lod > 0)
     {
@@ -199,7 +315,12 @@ EveSpaceObject.prototype.Update = function (dt)
     }
 };
 
-EveSpaceObject.prototype.GetLocatorCount = function (prefix)
+/**
+ * Gets locator count for a specific locator group
+ * @param {String} prefix
+ * @returns {number}
+ */
+EveSpaceObject.prototype.GetLocatorCount = function(prefix)
 {
     var count = 0;
     for (var i = 0; i < this.locators.length; ++i)
@@ -212,7 +333,12 @@ EveSpaceObject.prototype.GetLocatorCount = function (prefix)
     return count;
 };
 
-EveSpaceObject.prototype.FindLocatorJointByName = function (name)
+/**
+ * Finds a locator joint by it's name
+ * @param {String} name
+ * @returns {null|mat4}
+ */
+EveSpaceObject.prototype.FindLocatorJointByName = function(name)
 {
     var model = this.animation.FindModelForMesh(0);
     if (model != null)
@@ -228,7 +354,12 @@ EveSpaceObject.prototype.FindLocatorJointByName = function (name)
     return null;
 };
 
-EveSpaceObject.prototype.FindLocatorTransformByName = function (name)
+/**
+ * Finds a locator transform by it's name
+ * @param {String} name
+ * @returns {null|mat4}
+ */
+EveSpaceObject.prototype.FindLocatorTransformByName = function(name)
 {
     for (var i = 0; i < this.locators.length; ++i)
     {
@@ -240,10 +371,17 @@ EveSpaceObject.prototype.FindLocatorTransformByName = function (name)
     return null;
 };
 
-
-EveSpaceObject.prototype.RenderDebugInfo = function (debugHelper)
+/**
+ * RenderDebugInfo
+ * @param debugHelper
+ */
+EveSpaceObject.prototype.RenderDebugInfo = function(debugHelper)
 {
     this.animation.RenderDebugInfo(debugHelper);
 };
 
+/**
+ * EveStation inherits from EveSpaceObject
+ * @type {EveSpaceObject}
+ */
 EveStation = EveSpaceObject;


### PR DESCRIPTION
- Basic Documentation
- Beautified
- Added `lineSets` array
- Added `lineSets` view dependent data updating
- Added `displayLines` to toggle line set rendering
- Added `lineSets` to `GetBatches` @prototype
- Added `GetLineBatches` @prototype as a separate function so that users have an option to render them with a different accumulator than the other batches if need be
- Added `display` to toggle space object rendering
- Added `displayMesh` to toggle mesh rendering
- Added `displayChildren` to toggle child rendering
- Added `displayPlanes` to toggle planeSet rendering
- Added `displaySpotlights` to toggle spotlight rendering
- Added `displayDecals` to toggle decal rendering
- Added `displaySprites` to toggle sprite rendering
- Added `displayOverlays` to toggle overlay effect rendering