### PR TITLE
Added display options and `GetPickableBatches` to Tw2Mesh

### DIFF
--- a/src/core/Tw2Mesh.js
+++ b/src/core/Tw2Mesh.js
@@ -68,6 +68,12 @@ Tw2MeshLineArea.batchType = Tw2GeometryLineBatch;
  * @property {Array.<Tw2MeshArea>} decalAreas
  * @property {Array.<Tw2MeshArea>} depthAreas
  * @property {boolean} debugIsHidden
+ * @property {boolean} display - enables/disables all render batch accumulations
+ * @property {boolean} displayOpaque - enables/disables opaque area batch accumulations
+ * @property {boolean} displayTransparent - enables/disables transparent area batch accumulations
+ * @property {boolean} displayAdditive - enables/disables additive area batch accumulations
+ * @property {boolean} displayPickable - enables/disables pickable area batch accumulations
+ * @property {boolean} displayDecal - enables/disables decal area batch accumulations
  * @constructor
  */
 function Tw2Mesh()
@@ -77,12 +83,21 @@ function Tw2Mesh()
     this.geometryResPath = '';
     this.lowDetailGeometryResPath = '';
     this.geometryResource = null;
+
     this.opaqueAreas = [];
     this.transparentAreas = [];
     this.additiveAreas = [];
     this.pickableAreas = [];
     this.decalAreas = [];
     this.depthAreas = [];
+
+    this.display = true;
+    this.displayOpaque = true;
+    this.displayTransparent = true;
+    this.displayAdditive = true;
+    this.displayPickable = true;
+    this.displayDecal = true;
+
     this.debugIsHidden = false;
 }
 
@@ -141,21 +156,49 @@ Tw2Mesh.prototype.GetBatches = function(mode, accumulator, perObjectData)
     {
         return false;
     }
-    if (mode == device.RM_OPAQUE)
+
+    if (this.display)
     {
-        this._GetAreaBatches(this.opaqueAreas, mode, accumulator, perObjectData);
+
+        if (this.displayOpaque && mode == device.RM_OPAQUE)
+        {
+            this._GetAreaBatches(this.opaqueAreas, mode, accumulator, perObjectData);
+        }
+        else if (this.displayDecal && mode == device.RM_DECAL)
+        {
+            this._GetAreaBatches(this.decalAreas, mode, accumulator, perObjectData);
+        }
+        else if (this.displayTransparent && mode == device.RM_TRANSPARENT)
+        {
+            this._GetAreaBatches(this.transparentAreas, mode, accumulator, perObjectData);
+        }
+        else if (this.displayAdditive && mode == device.RM_ADDITIVE)
+        {
+            this._GetAreaBatches(this.additiveAreas, mode, accumulator, perObjectData);
+        }
     }
-    else if (mode == device.RM_DECAL)
-    {
-        this._GetAreaBatches(this.decalAreas, mode, accumulator, perObjectData);
-    }
-    else if (mode == device.RM_TRANSPARENT)
-    {
-        this._GetAreaBatches(this.transparentAreas, mode, accumulator, perObjectData);
-    }
-    else if (mode == device.RM_ADDITIVE)
-    {
-        this._GetAreaBatches(this.additiveAreas, mode, accumulator, perObjectData);
-    }
+
     return true;
 };
+
+/**
+ * Gets pickable render batches
+ * @param {Tw2BatchAccumulator} accumulator
+ * @param {Tw2PerObjectData} perObjectData
+ * @returns {boolean}
+ * @constructor
+ */
+Tw2Mesh.prototype.GetPickableBatches = function(accumulator, perObjectData)
+{
+    if (this.geometryResource == null || this.debugIsHidden)
+    {
+        return false;
+    }
+
+    if (this.display && this.displayPickable)
+    {
+        this._GetAreaBatches(this.pickableAreas, device.RM_OPAQUE, accumulator, perObjectData);
+    }
+
+    return true;
+}

--- a/src/core/Tw2Mesh.js
+++ b/src/core/Tw2Mesh.js
@@ -5,7 +5,7 @@
  * @property {number} meshIndex
  * @property {number} index
  * @property {number} count
- * @property {boolean} debugIsHidden
+ * @property {boolean} display
  * @constructor
  */
 function Tw2MeshArea()
@@ -15,7 +15,7 @@ function Tw2MeshArea()
     this.meshIndex = 0;
     this.index = 0;
     this.count = 1;
-    this.debugIsHidden = false;
+    this.display = true;
 }
 
 /**
@@ -33,7 +33,7 @@ Tw2MeshArea.batchType = Tw2GeometryBatch;
  * @property {number} meshIndex
  * @property {number} index
  * @property {number} count
- * @property {boolean} debugIsHidden
+ * @property {Boolean} display
  * @constructor
  */
 function Tw2MeshLineArea()
@@ -43,7 +43,7 @@ function Tw2MeshLineArea()
     this.meshIndex = 0;
     this.index = 0;
     this.count = 1;
-    this.debugIsHidden = false;
+    this.display = true;
 }
 
 /**
@@ -67,7 +67,6 @@ Tw2MeshLineArea.batchType = Tw2GeometryLineBatch;
  * @property {Array.<Tw2MeshArea>} pickableAreas
  * @property {Array.<Tw2MeshArea>} decalAreas
  * @property {Array.<Tw2MeshArea>} depthAreas
- * @property {boolean} debugIsHidden
  * @property {boolean} display - enables/disables all render batch accumulations
  * @property {boolean} displayOpaque - enables/disables opaque area batch accumulations
  * @property {boolean} displayTransparent - enables/disables transparent area batch accumulations
@@ -97,8 +96,6 @@ function Tw2Mesh()
     this.displayAdditive = true;
     this.displayPickable = true;
     this.displayDecal = true;
-
-    this.debugIsHidden = false;
 }
 
 /**
@@ -126,7 +123,7 @@ Tw2Mesh.prototype._GetAreaBatches = function(areas, mode, accumulator, perObject
     for (var i = 0; i < areas.length; ++i)
     {
         var area = areas[i];
-        if (area.effect == null || area.debugIsHidden)
+        if (area.effect == null || !area.display))
         {
             continue;
         }
@@ -152,7 +149,7 @@ Tw2Mesh.prototype._GetAreaBatches = function(areas, mode, accumulator, perObject
  */
 Tw2Mesh.prototype.GetBatches = function(mode, accumulator, perObjectData)
 {
-    if (this.geometryResource == null || this.debugIsHidden)
+    if (this.geometryResource == null)
     {
         return false;
     }
@@ -190,7 +187,7 @@ Tw2Mesh.prototype.GetBatches = function(mode, accumulator, perObjectData)
  */
 Tw2Mesh.prototype.GetPickableBatches = function(accumulator, perObjectData)
 {
-    if (this.geometryResource == null || this.debugIsHidden)
+    if (this.geometryResource == null)
     {
         return false;
     }


### PR DESCRIPTION
* added @property `display` which enables/disables all render batch accumulations
* added @property `displayOpaque` which  enables/disables opaque area batch accumulations
* added @property `displayTransparent` which enables/disables transparent area batch accumulations
* added @property `displayAdditive` which enables/disables additive area batch accumulations
* added @property `displayPickable` which enables/disables pickable area batch accumulations
* added @property `displayDecal` which  enables/disables decal area batch accumulations
* added @prototype `GetPickableBatches` for accumulating pickable batch renders