### PR TITLE
Added static method to Tw2VariableStore

### DIFF
--- a/src/core/Tw2VariableStore.js
+++ b/src/core/Tw2VariableStore.js
@@ -34,41 +34,49 @@ Tw2VariableStore.prototype.RegisterType = function(name, type)
 };
 
 /**
- * Registers a variable without a type
- * @param {string} name
- * @param {string|number|Float32Array|vec3|mat4} value
- * @returns {Tw2Parameter}
- * @constructor
+ * Gets A Tw2 parameter constructor from a supplied value
+ * @param {Number|String|Array.<Number>|Float32Array} value
+ * @returns {null|Function}
  */
-Tw2VariableStore.prototype.RegisterVariable = function(name, value)
+Tw2VariableStore.GetTw2ParameterType = function (value)
 {
-    if (value.constructor == (new glMatrixArrayType()).constructor)
+    if (value.constructor === (new glMatrixArrayType()).constructor || Object.prototype.toString.apply(value) === '[object Array]')
     {
-        if (value.length == 16)
+        switch (value.length)
         {
-            return this.RegisterVariableWithType(name, value, Tw2MatrixParameter);
-        }
-        else if (value.length == 4)
-        {
-            return this.RegisterVariableWithType(name, value, Tw2Vector4Parameter);
-        }
-        else if (value.length == 3)
-        {
-            return this.RegisterVariableWithType(name, value, Tw2Vector3Parameter);
-        }
-        else if (value.length == 2)
-        {
-            return this.RegisterVariableWithType(name, value, Tw2Vector2Parameter);
+            case(16):
+                return Tw2MatrixParameter;
+
+            case(4):
+                return Tw2Vector4Parameter;
+
+            case(3):
+                return Tw2Vector3Parameter;
+
+            case(2):
+                return Tw2Vector2Parameter;
         }
     }
     else if (typeof(value) == 'number')
     {
-        return this.RegisterVariableWithType(name, value, Tw2FloatParameter);
+        return Tw2FloatParameter;
     }
     else if (typeof(value) == 'string')
     {
-        return this.RegisterVariableWithType(name, value, Tw2TextureParameter);
+        return Tw2TextureParameter;
     }
+}
+
+/**
+ * Registers a variable without a type
+ * @param {string} name
+ * @param {string|number|Float32Array} value
+ * @returns {Tw2Parameter}
+ * @constructor
+ */
+Tw2VariableStore.prototype.RegisterVariable = function (name, value)
+{
+    return this.RegisterVariableWithType(name, value, Tw2VariableStore.GetTw2ParameterConstructor(value));
 };
 
 var variableStore = new Tw2VariableStore();

--- a/src/core/Tw2VariableStore.js
+++ b/src/core/Tw2VariableStore.js
@@ -76,7 +76,7 @@ Tw2VariableStore.GetTw2ParameterType = function (value)
  */
 Tw2VariableStore.prototype.RegisterVariable = function (name, value)
 {
-    return this.RegisterVariableWithType(name, value, Tw2VariableStore.GetTw2ParameterConstructor(value));
+    return this.RegisterVariableWithType(name, value, Tw2VariableStore.GetTw2ParameterType(value));
 };
 
 var variableStore = new Tw2VariableStore();

--- a/src/core/Tw2VariableStore.js
+++ b/src/core/Tw2VariableStore.js
@@ -40,7 +40,7 @@ Tw2VariableStore.prototype.RegisterType = function(name, type)
  */
 Tw2VariableStore.GetTw2ParameterType = function (value)
 {
-    if (value.constructor === (new glMatrixArrayType()).constructor || Object.prototype.toString.apply(value) === '[object Array]')
+    if (value.constructor === (new glMatrixArrayType()).constructor || value.constructor===[].constructor)
     {
         switch (value.length)
         {


### PR DESCRIPTION
- Added `GetTw2ParameterType` static method which gets a Tw2 Parameter constructor from a supplied value
- This code already existed in the `RegisterVariable` @prototype but it couldn't be used without registering a variable (which may not be wanted)
- Added support for standard array values

`Tw2VariableParameters` could also be identified from a value but I'm not sure if this will cause issues anywhere without further testing, and it would need to be updated if any new texture formats were supported in the future
```
if (value.indexOf('.png') != -1 || value.indexOf('.cube') != -1)
{
    return Tw2TextureParameter;
}
return Tw2VariableParameter;
```