### PR TITLE
Various minor fixes

### DIFF
--- a/src/core/Tw2Device.js
+++ b/src/core/Tw2Device.js
@@ -33,45 +33,45 @@ function Tw2Device()
     this.RM_DEPTH = 4;
     this.RM_FULLSCREEN = 5;
 
-    this.RS_ZENABLE = 7; /* D3DZBUFFERTYPE (or TRUE/FALSE for legacy) */
-    this.RS_FILLMODE = 8; /* D3DFILLMODE */
-    this.RS_SHADEMODE = 9; /* D3DSHADEMODE */
-    this.RS_ZWRITEENABLE = 14; /* TRUE to enable z writes */
-    this.RS_ALPHATESTENABLE = 15; /* TRUE to enable alpha tests */
-    this.RS_LASTPIXEL = 16; /* TRUE for last-pixel on lines */
-    this.RS_SRCBLEND = 19; /* D3DBLEND */
-    this.RS_DESTBLEND = 20; /* D3DBLEND */
-    this.RS_CULLMODE = 22; /* D3DCULL */
-    this.RS_ZFUNC = 23; /* D3DCMPFUNC */
-    this.RS_ALPHAREF = 24; /* D3DFIXED */
-    this.RS_ALPHAFUNC = 25; /* D3DCMPFUNC */
-    this.RS_DITHERENABLE = 26; /* TRUE to enable dithering */
-    this.RS_ALPHABLENDENABLE = 27; /* TRUE to enable alpha blending */
-    this.RS_FOGENABLE = 28; /* TRUE to enable fog blending */
-    this.RS_SPECULARENABLE = 29; /* TRUE to enable specular */
-    this.RS_FOGCOLOR = 34; /* D3DCOLOR */
-    this.RS_FOGTABLEMODE = 35; /* D3DFOGMODE */
-    this.RS_FOGSTART = 36; /* Fog start (for both vertex and pixel fog) */
-    this.RS_FOGEND = 37; /* Fog end      */
-    this.RS_FOGDENSITY = 38; /* Fog density  */
-    this.RS_RANGEFOGENABLE = 48; /* Enables range-based fog */
-    this.RS_STENCILENABLE = 52; /* BOOL enable/disable stenciling */
-    this.RS_STENCILFAIL = 53; /* D3DSTENCILOP to do if stencil test fails */
-    this.RS_STENCILZFAIL = 54; /* D3DSTENCILOP to do if stencil test passes and Z test fails */
-    this.RS_STENCILPASS = 55; /* D3DSTENCILOP to do if both stencil and Z tests pass */
-    this.RS_STENCILFUNC = 56; /* D3DCMPFUNC fn.  Stencil Test passes if ((ref & mask) stencilfn (stencil & mask)) is true */
-    this.RS_STENCILREF = 57; /* Reference value used in stencil test */
-    this.RS_STENCILMASK = 58; /* Mask value used in stencil test */
-    this.RS_STENCILWRITEMASK = 59; /* Write mask applied to values written to stencil buffer */
-    this.RS_TEXTUREFACTOR = 60; /* D3DCOLOR used for multi-texture blend */
-    this.RS_WRAP0 = 128; /* wrap for 1st texture coord. set */
-    this.RS_WRAP1 = 129; /* wrap for 2nd texture coord. set */
-    this.RS_WRAP2 = 130; /* wrap for 3rd texture coord. set */
-    this.RS_WRAP3 = 131; /* wrap for 4th texture coord. set */
-    this.RS_WRAP4 = 132; /* wrap for 5th texture coord. set */
-    this.RS_WRAP5 = 133; /* wrap for 6th texture coord. set */
-    this.RS_WRAP6 = 134; /* wrap for 7th texture coord. set */
-    this.RS_WRAP7 = 135; /* wrap for 8th texture coord. set */
+    this.RS_ZENABLE = 7;                    /* D3DZBUFFERTYPE (or TRUE/FALSE for legacy) */
+    this.RS_FILLMODE = 8;                   /* D3DFILLMODE */
+    this.RS_SHADEMODE = 9;                  /* D3DSHADEMODE */
+    this.RS_ZWRITEENABLE = 14;              /* TRUE to enable z writes */
+    this.RS_ALPHATESTENABLE = 15;           /* TRUE to enable alpha tests */
+    this.RS_LASTPIXEL = 16;                 /* TRUE for last-pixel on lines */
+    this.RS_SRCBLEND = 19;                  /* D3DBLEND */
+    this.RS_DESTBLEND = 20;                 /* D3DBLEND */
+    this.RS_CULLMODE = 22;                  /* D3DCULL */
+    this.RS_ZFUNC = 23;                     /* D3DCMPFUNC */
+    this.RS_ALPHAREF = 24;                  /* D3DFIXED */
+    this.RS_ALPHAFUNC = 25;                 /* D3DCMPFUNC */
+    this.RS_DITHERENABLE = 26;              /* TRUE to enable dithering */
+    this.RS_ALPHABLENDENABLE = 27;          /* TRUE to enable alpha blending */
+    this.RS_FOGENABLE = 28;                 /* TRUE to enable fog blending */
+    this.RS_SPECULARENABLE = 29;            /* TRUE to enable specular */
+    this.RS_FOGCOLOR = 34;                  /* D3DCOLOR */
+    this.RS_FOGTABLEMODE = 35;              /* D3DFOGMODE */
+    this.RS_FOGSTART = 36;                  /* Fog start (for both vertex and pixel fog) */
+    this.RS_FOGEND = 37;                    /* Fog end      */
+    this.RS_FOGDENSITY = 38;                /* Fog density  */
+    this.RS_RANGEFOGENABLE = 48;            /* Enables range-based fog */
+    this.RS_STENCILENABLE = 52;             /* BOOL enable/disable stenciling */
+    this.RS_STENCILFAIL = 53;               /* D3DSTENCILOP to do if stencil test fails */
+    this.RS_STENCILZFAIL = 54;              /* D3DSTENCILOP to do if stencil test passes and Z test fails */
+    this.RS_STENCILPASS = 55;               /* D3DSTENCILOP to do if both stencil and Z tests pass */
+    this.RS_STENCILFUNC = 56;               /* D3DCMPFUNC fn.  Stencil Test passes if ((ref & mask) stencilfn (stencil & mask)) is true */
+    this.RS_STENCILREF = 57;                /* Reference value used in stencil test */
+    this.RS_STENCILMASK = 58;               /* Mask value used in stencil test */
+    this.RS_STENCILWRITEMASK = 59;          /* Write mask applied to values written to stencil buffer */
+    this.RS_TEXTUREFACTOR = 60;             /* D3DCOLOR used for multi-texture blend */
+    this.RS_WRAP0 = 128;                    /* wrap for 1st texture coord. set */
+    this.RS_WRAP1 = 129;                    /* wrap for 2nd texture coord. set */
+    this.RS_WRAP2 = 130;                    /* wrap for 3rd texture coord. set */
+    this.RS_WRAP3 = 131;                    /* wrap for 4th texture coord. set */
+    this.RS_WRAP4 = 132;                    /* wrap for 5th texture coord. set */
+    this.RS_WRAP5 = 133;                    /* wrap for 6th texture coord. set */
+    this.RS_WRAP6 = 134;                    /* wrap for 7th texture coord. set */
+    this.RS_WRAP7 = 135;                    /* wrap for 8th texture coord. set */
     this.RS_CLIPPING = 136;
     this.RS_LIGHTING = 137;
     this.RS_AMBIENT = 139;
@@ -85,42 +85,42 @@ function Tw2Device()
     this.RS_EMISSIVEMATERIALSOURCE = 148;
     this.RS_VERTEXBLEND = 151;
     this.RS_CLIPPLANEENABLE = 152;
-    this.RS_POINTSIZE = 154; /* float point size */
-    this.RS_POINTSIZE_MIN = 155; /* float point size min threshold */
-    this.RS_POINTSPRITEENABLE = 156; /* BOOL point texture coord control */
-    this.RS_POINTSCALEENABLE = 157; /* BOOL point size scale enable */
-    this.RS_POINTSCALE_A = 158; /* float point attenuation A value */
-    this.RS_POINTSCALE_B = 159; /* float point attenuation B value */
-    this.RS_POINTSCALE_C = 160; /* float point attenuation C value */
-    this.RS_MULTISAMPLEANTIALIAS = 161; // BOOL - set to do FSAA with multisample buffer
-    this.RS_MULTISAMPLEMASK = 162; // DWORD - per-sample enable/disable
-    this.RS_PATCHEDGESTYLE = 163; // Sets whether patch edges will use float style tessellation
-    this.RS_DEBUGMONITORTOKEN = 165; // DEBUG ONLY - token to debug monitor
-    this.RS_POINTSIZE_MAX = 166; /* float point size max threshold */
+    this.RS_POINTSIZE = 154;                /* float point size */
+    this.RS_POINTSIZE_MIN = 155;            /* float point size min threshold */
+    this.RS_POINTSPRITEENABLE = 156;        /* BOOL point texture coord control */
+    this.RS_POINTSCALEENABLE = 157;         /* BOOL point size scale enable */
+    this.RS_POINTSCALE_A = 158;             /* float point attenuation A value */
+    this.RS_POINTSCALE_B = 159;             /* float point attenuation B value */
+    this.RS_POINTSCALE_C = 160;             /* float point attenuation C value */
+    this.RS_MULTISAMPLEANTIALIAS = 161;     // BOOL - set to do FSAA with multisample buffer
+    this.RS_MULTISAMPLEMASK = 162;          // DWORD - per-sample enable/disable
+    this.RS_PATCHEDGESTYLE = 163;           // Sets whether patch edges will use float style tessellation
+    this.RS_DEBUGMONITORTOKEN = 165;        // DEBUG ONLY - token to debug monitor
+    this.RS_POINTSIZE_MAX = 166;            /* float point size max threshold */
     this.RS_INDEXEDVERTEXBLENDENABLE = 167;
-    this.RS_COLORWRITEENABLE = 168; // per-channel write enable
-    this.RS_TWEENFACTOR = 170; // float tween factor
-    this.RS_BLENDOP = 171; // D3DBLENDOP setting
-    this.RS_POSITIONDEGREE = 172; // NPatch position interpolation degree. D3DDEGREE_LINEAR or D3DDEGREE_CUBIC (default)
-    this.RS_NORMALDEGREE = 173; // NPatch normal interpolation degree. D3DDEGREE_LINEAR (default) or D3DDEGREE_QUADRATIC
+    this.RS_COLORWRITEENABLE = 168;         // per-channel write enable
+    this.RS_TWEENFACTOR = 170;              // float tween factor
+    this.RS_BLENDOP = 171;                  // D3DBLENDOP setting
+    this.RS_POSITIONDEGREE = 172;           // NPatch position interpolation degree. D3DDEGREE_LINEAR or D3DDEGREE_CUBIC (default)
+    this.RS_NORMALDEGREE = 173;             // NPatch normal interpolation degree. D3DDEGREE_LINEAR (default) or D3DDEGREE_QUADRATIC
     this.RS_SCISSORTESTENABLE = 174;
     this.RS_SLOPESCALEDEPTHBIAS = 175;
     this.RS_ANTIALIASEDLINEENABLE = 176;
-    this.RS_TWOSIDEDSTENCILMODE = 185; /* BOOL enable/disable 2 sided stenciling */
-    this.RS_CCW_STENCILFAIL = 186; /* D3DSTENCILOP to do if ccw stencil test fails */
-    this.RS_CCW_STENCILZFAIL = 187; /* D3DSTENCILOP to do if ccw stencil test passes and Z test fails */
-    this.RS_CCW_STENCILPASS = 188; /* D3DSTENCILOP to do if both ccw stencil and Z tests pass */
-    this.RS_CCW_STENCILFUNC = 189; /* D3DCMPFUNC fn.  ccw Stencil Test passes if ((ref & mask) stencilfn (stencil & mask)) is true */
-    this.RS_COLORWRITEENABLE1 = 190; /* Additional ColorWriteEnables for the devices that support D3DPMISCCAPS_INDEPENDENTWRITEMASKS */
-    this.RS_COLORWRITEENABLE2 = 191; /* Additional ColorWriteEnables for the devices that support D3DPMISCCAPS_INDEPENDENTWRITEMASKS */
-    this.RS_COLORWRITEENABLE3 = 192; /* Additional ColorWriteEnables for the devices that support D3DPMISCCAPS_INDEPENDENTWRITEMASKS */
-    this.RS_BLENDFACTOR = 193; /* D3DCOLOR used for a constant blend factor during alpha blending for devices that support D3DPBLENDCAPS_BLENDFACTOR */
-    this.RS_SRGBWRITEENABLE = 194; /* Enable rendertarget writes to be DE-linearized to SRGB (for formats that expose D3DUSAGE_QUERY_SRGBWRITE) */
+    this.RS_TWOSIDEDSTENCILMODE = 185;      /* BOOL enable/disable 2 sided stenciling */
+    this.RS_CCW_STENCILFAIL = 186;          /* D3DSTENCILOP to do if ccw stencil test fails */
+    this.RS_CCW_STENCILZFAIL = 187;         /* D3DSTENCILOP to do if ccw stencil test passes and Z test fails */
+    this.RS_CCW_STENCILPASS = 188;          /* D3DSTENCILOP to do if both ccw stencil and Z tests pass */
+    this.RS_CCW_STENCILFUNC = 189;          /* D3DCMPFUNC fn.  ccw Stencil Test passes if ((ref & mask) stencilfn (stencil & mask)) is true */
+    this.RS_COLORWRITEENABLE1 = 190;        /* Additional ColorWriteEnables for the devices that support D3DPMISCCAPS_INDEPENDENTWRITEMASKS */
+    this.RS_COLORWRITEENABLE2 = 191;        /* Additional ColorWriteEnables for the devices that support D3DPMISCCAPS_INDEPENDENTWRITEMASKS */
+    this.RS_COLORWRITEENABLE3 = 192;        /* Additional ColorWriteEnables for the devices that support D3DPMISCCAPS_INDEPENDENTWRITEMASKS */
+    this.RS_BLENDFACTOR = 193;              /* D3DCOLOR used for a constant blend factor during alpha blending for devices that support D3DPBLENDCAPS_BLENDFACTOR */
+    this.RS_SRGBWRITEENABLE = 194;          /* Enable rendertarget writes to be DE-linearized to SRGB (for formats that expose D3DUSAGE_QUERY_SRGBWRITE) */
     this.RS_DEPTHBIAS = 195;
     this.RS_SEPARATEALPHABLENDENABLE = 206; /* TRUE to enable a separate blending function for the alpha channel */
-    this.RS_SRCBLENDALPHA = 207; /* SRC blend factor for the alpha channel when RS_SEPARATEDESTALPHAENABLE is TRUE */
-    this.RS_DESTBLENDALPHA = 208; /* DST blend factor for the alpha channel when RS_SEPARATEDESTALPHAENABLE is TRUE */
-    this.RS_BLENDOPALPHA = 209; /* Blending operation for the alpha channel when RS_SEPARATEDESTALPHAENABLE is TRUE */
+    this.RS_SRCBLENDALPHA = 207;            /* SRC blend factor for the alpha channel when RS_SEPARATEDESTALPHAENABLE is TRUE */
+    this.RS_DESTBLENDALPHA = 208;           /* DST blend factor for the alpha channel when RS_SEPARATEDESTALPHAENABLE is TRUE */
+    this.RS_BLENDOPALPHA = 209;             /* Blending operation for the alpha channel when RS_SEPARATEDESTALPHAENABLE is TRUE */
 
     this.CULL_NONE = 1;
     this.CULL_CW = 2;
@@ -302,22 +302,23 @@ function Tw2Device()
         this.depthOffsetState.states[this.RS_DEPTHBIAS] = 0;
         this.depthOffsetState.dirty = false;
 
-        this._blendTable = [-1, // --
-            this.gl.ZERO, // D3DBLEND_ZERO
-            this.gl.ONE, // D3DBLEND_ONE
-            this.gl.SRC_COLOR, // D3DBLEND_SRCCOLOR
-            this.gl.ONE_MINUS_SRC_COLOR, // D3DBLEND_INVSRCCOLOR
-            this.gl.SRC_ALPHA, // D3DBLEND_SRCALPHA
-            this.gl.ONE_MINUS_SRC_ALPHA, // D3DBLEND_INVSRCALPHA
-            this.gl.DST_ALPHA, // D3DBLEND_DESTALPHA
-            this.gl.ONE_MINUS_DST_ALPHA, // D3DBLEND_INVDESTALPHA
-            this.gl.DST_COLOR, // D3DBLEND_DESTCOLOR
-            this.gl.ONE_MINUS_DST_COLOR, // D3DBLEND_INVDESTCOLOR
-            this.gl.SRC_ALPHA_SATURATE, // D3DBLEND_SRCALPHASAT
-            -1, // D3DBLEND_BOTHSRCALPHA
-            -1, // D3DBLEND_BOTHINVSRCALPHA
-            this.gl.CONSTANT_COLOR, // D3DBLEND_BLENDFACTOR
-            this.gl.ONE_MINUS_CONSTANT_COLOR // D3DBLEND_INVBLENDFACTOR
+        this._blendTable = [
+            -1,                                 // --
+            this.gl.ZERO,                       // D3DBLEND_ZERO
+            this.gl.ONE,                        // D3DBLEND_ONE
+            this.gl.SRC_COLOR,                  // D3DBLEND_SRCCOLOR
+            this.gl.ONE_MINUS_SRC_COLOR,        // D3DBLEND_INVSRCCOLOR
+            this.gl.SRC_ALPHA,                  // D3DBLEND_SRCALPHA
+            this.gl.ONE_MINUS_SRC_ALPHA,        // D3DBLEND_INVSRCALPHA
+            this.gl.DST_ALPHA,                  // D3DBLEND_DESTALPHA
+            this.gl.ONE_MINUS_DST_ALPHA,        // D3DBLEND_INVDESTALPHA
+            this.gl.DST_COLOR,                  // D3DBLEND_DESTCOLOR
+            this.gl.ONE_MINUS_DST_COLOR,        // D3DBLEND_INVDESTCOLOR
+            this.gl.SRC_ALPHA_SATURATE,         // D3DBLEND_SRCALPHASAT
+            -1,                                 // D3DBLEND_BOTHSRCALPHA
+            -1,                                 // D3DBLEND_BOTHINVSRCALPHA
+            this.gl.CONSTANT_COLOR,             // D3DBLEND_BLENDFACTOR
+            this.gl.ONE_MINUS_CONSTANT_COLOR    // D3DBLEND_INVBLENDFACTOR
         ];
 
         this._shadowStateBuffer = new Float32Array(24);

--- a/src/core/Tw2Device.js
+++ b/src/core/Tw2Device.js
@@ -2,7 +2,7 @@
  * RenderMode
  * @typedef {(device.RM_ANY|device.RM_OPAQUE|device.RM_DECAL|device.RM_TRANSPARENT|device.RM_ADDITIVE|device.RM_DEPTH|device.RM_FULLSCREEN)} RenderMode
  */
- 
+
 window.requestAnimFrame = (function()
 {
     return window.requestAnimationFrame ||
@@ -33,45 +33,45 @@ function Tw2Device()
     this.RM_DEPTH = 4;
     this.RM_FULLSCREEN = 5;
 
-    this.RS_ZENABLE = 7;                    /* D3DZBUFFERTYPE (or TRUE/FALSE for legacy) */
-    this.RS_FILLMODE = 8;                   /* D3DFILLMODE */
-    this.RS_SHADEMODE = 9;                  /* D3DSHADEMODE */
-    this.RS_ZWRITEENABLE = 14;              /* TRUE to enable z writes */
-    this.RS_ALPHATESTENABLE = 15;           /* TRUE to enable alpha tests */
-    this.RS_LASTPIXEL = 16;                 /* TRUE for last-pixel on lines */
-    this.RS_SRCBLEND = 19;                  /* D3DBLEND */
-    this.RS_DESTBLEND = 20;                 /* D3DBLEND */
-    this.RS_CULLMODE = 22;                  /* D3DCULL */
-    this.RS_ZFUNC = 23;                     /* D3DCMPFUNC */
-    this.RS_ALPHAREF = 24;                  /* D3DFIXED */
-    this.RS_ALPHAFUNC = 25;                 /* D3DCMPFUNC */
-    this.RS_DITHERENABLE = 26;              /* TRUE to enable dithering */
-    this.RS_ALPHABLENDENABLE = 27;          /* TRUE to enable alpha blending */
-    this.RS_FOGENABLE = 28;                 /* TRUE to enable fog blending */
-    this.RS_SPECULARENABLE = 29;            /* TRUE to enable specular */
-    this.RS_FOGCOLOR = 34;                  /* D3DCOLOR */
-    this.RS_FOGTABLEMODE = 35;              /* D3DFOGMODE */
-    this.RS_FOGSTART = 36;                  /* Fog start (for both vertex and pixel fog) */
-    this.RS_FOGEND = 37;                    /* Fog end      */
-    this.RS_FOGDENSITY = 38;                /* Fog density  */
-    this.RS_RANGEFOGENABLE = 48;            /* Enables range-based fog */
-    this.RS_STENCILENABLE = 52;             /* BOOL enable/disable stenciling */
-    this.RS_STENCILFAIL = 53;               /* D3DSTENCILOP to do if stencil test fails */
-    this.RS_STENCILZFAIL = 54;              /* D3DSTENCILOP to do if stencil test passes and Z test fails */
-    this.RS_STENCILPASS = 55;               /* D3DSTENCILOP to do if both stencil and Z tests pass */
-    this.RS_STENCILFUNC = 56;               /* D3DCMPFUNC fn.  Stencil Test passes if ((ref & mask) stencilfn (stencil & mask)) is true */
-    this.RS_STENCILREF = 57;                /* Reference value used in stencil test */
-    this.RS_STENCILMASK = 58;               /* Mask value used in stencil test */
-    this.RS_STENCILWRITEMASK = 59;          /* Write mask applied to values written to stencil buffer */
-    this.RS_TEXTUREFACTOR = 60;             /* D3DCOLOR used for multi-texture blend */
-    this.RS_WRAP0 = 128;                    /* wrap for 1st texture coord. set */
-    this.RS_WRAP1 = 129;                    /* wrap for 2nd texture coord. set */
-    this.RS_WRAP2 = 130;                    /* wrap for 3rd texture coord. set */
-    this.RS_WRAP3 = 131;                    /* wrap for 4th texture coord. set */
-    this.RS_WRAP4 = 132;                    /* wrap for 5th texture coord. set */
-    this.RS_WRAP5 = 133;                    /* wrap for 6th texture coord. set */
-    this.RS_WRAP6 = 134;                    /* wrap for 7th texture coord. set */
-    this.RS_WRAP7 = 135;                    /* wrap for 8th texture coord. set */
+    this.RS_ZENABLE = 7; /* D3DZBUFFERTYPE (or TRUE/FALSE for legacy) */
+    this.RS_FILLMODE = 8; /* D3DFILLMODE */
+    this.RS_SHADEMODE = 9; /* D3DSHADEMODE */
+    this.RS_ZWRITEENABLE = 14; /* TRUE to enable z writes */
+    this.RS_ALPHATESTENABLE = 15; /* TRUE to enable alpha tests */
+    this.RS_LASTPIXEL = 16; /* TRUE for last-pixel on lines */
+    this.RS_SRCBLEND = 19; /* D3DBLEND */
+    this.RS_DESTBLEND = 20; /* D3DBLEND */
+    this.RS_CULLMODE = 22; /* D3DCULL */
+    this.RS_ZFUNC = 23; /* D3DCMPFUNC */
+    this.RS_ALPHAREF = 24; /* D3DFIXED */
+    this.RS_ALPHAFUNC = 25; /* D3DCMPFUNC */
+    this.RS_DITHERENABLE = 26; /* TRUE to enable dithering */
+    this.RS_ALPHABLENDENABLE = 27; /* TRUE to enable alpha blending */
+    this.RS_FOGENABLE = 28; /* TRUE to enable fog blending */
+    this.RS_SPECULARENABLE = 29; /* TRUE to enable specular */
+    this.RS_FOGCOLOR = 34; /* D3DCOLOR */
+    this.RS_FOGTABLEMODE = 35; /* D3DFOGMODE */
+    this.RS_FOGSTART = 36; /* Fog start (for both vertex and pixel fog) */
+    this.RS_FOGEND = 37; /* Fog end      */
+    this.RS_FOGDENSITY = 38; /* Fog density  */
+    this.RS_RANGEFOGENABLE = 48; /* Enables range-based fog */
+    this.RS_STENCILENABLE = 52; /* BOOL enable/disable stenciling */
+    this.RS_STENCILFAIL = 53; /* D3DSTENCILOP to do if stencil test fails */
+    this.RS_STENCILZFAIL = 54; /* D3DSTENCILOP to do if stencil test passes and Z test fails */
+    this.RS_STENCILPASS = 55; /* D3DSTENCILOP to do if both stencil and Z tests pass */
+    this.RS_STENCILFUNC = 56; /* D3DCMPFUNC fn.  Stencil Test passes if ((ref & mask) stencilfn (stencil & mask)) is true */
+    this.RS_STENCILREF = 57; /* Reference value used in stencil test */
+    this.RS_STENCILMASK = 58; /* Mask value used in stencil test */
+    this.RS_STENCILWRITEMASK = 59; /* Write mask applied to values written to stencil buffer */
+    this.RS_TEXTUREFACTOR = 60; /* D3DCOLOR used for multi-texture blend */
+    this.RS_WRAP0 = 128; /* wrap for 1st texture coord. set */
+    this.RS_WRAP1 = 129; /* wrap for 2nd texture coord. set */
+    this.RS_WRAP2 = 130; /* wrap for 3rd texture coord. set */
+    this.RS_WRAP3 = 131; /* wrap for 4th texture coord. set */
+    this.RS_WRAP4 = 132; /* wrap for 5th texture coord. set */
+    this.RS_WRAP5 = 133; /* wrap for 6th texture coord. set */
+    this.RS_WRAP6 = 134; /* wrap for 7th texture coord. set */
+    this.RS_WRAP7 = 135; /* wrap for 8th texture coord. set */
     this.RS_CLIPPING = 136;
     this.RS_LIGHTING = 137;
     this.RS_AMBIENT = 139;
@@ -85,42 +85,42 @@ function Tw2Device()
     this.RS_EMISSIVEMATERIALSOURCE = 148;
     this.RS_VERTEXBLEND = 151;
     this.RS_CLIPPLANEENABLE = 152;
-    this.RS_POINTSIZE = 154;                /* float point size */
-    this.RS_POINTSIZE_MIN = 155;            /* float point size min threshold */
-    this.RS_POINTSPRITEENABLE = 156;        /* BOOL point texture coord control */
-    this.RS_POINTSCALEENABLE = 157;         /* BOOL point size scale enable */
-    this.RS_POINTSCALE_A = 158;             /* float point attenuation A value */
-    this.RS_POINTSCALE_B = 159;             /* float point attenuation B value */
-    this.RS_POINTSCALE_C = 160;             /* float point attenuation C value */
-    this.RS_MULTISAMPLEANTIALIAS = 161;     // BOOL - set to do FSAA with multisample buffer
-    this.RS_MULTISAMPLEMASK = 162;          // DWORD - per-sample enable/disable
-    this.RS_PATCHEDGESTYLE = 163;           // Sets whether patch edges will use float style tessellation
-    this.RS_DEBUGMONITORTOKEN = 165;        // DEBUG ONLY - token to debug monitor
-    this.RS_POINTSIZE_MAX = 166;            /* float point size max threshold */
+    this.RS_POINTSIZE = 154; /* float point size */
+    this.RS_POINTSIZE_MIN = 155; /* float point size min threshold */
+    this.RS_POINTSPRITEENABLE = 156; /* BOOL point texture coord control */
+    this.RS_POINTSCALEENABLE = 157; /* BOOL point size scale enable */
+    this.RS_POINTSCALE_A = 158; /* float point attenuation A value */
+    this.RS_POINTSCALE_B = 159; /* float point attenuation B value */
+    this.RS_POINTSCALE_C = 160; /* float point attenuation C value */
+    this.RS_MULTISAMPLEANTIALIAS = 161; // BOOL - set to do FSAA with multisample buffer
+    this.RS_MULTISAMPLEMASK = 162; // DWORD - per-sample enable/disable
+    this.RS_PATCHEDGESTYLE = 163; // Sets whether patch edges will use float style tessellation
+    this.RS_DEBUGMONITORTOKEN = 165; // DEBUG ONLY - token to debug monitor
+    this.RS_POINTSIZE_MAX = 166; /* float point size max threshold */
     this.RS_INDEXEDVERTEXBLENDENABLE = 167;
-    this.RS_COLORWRITEENABLE = 168;         // per-channel write enable
-    this.RS_TWEENFACTOR = 170;              // float tween factor
-    this.RS_BLENDOP = 171;                  // D3DBLENDOP setting
-    this.RS_POSITIONDEGREE = 172;           // NPatch position interpolation degree. D3DDEGREE_LINEAR or D3DDEGREE_CUBIC (default)
-    this.RS_NORMALDEGREE = 173;             // NPatch normal interpolation degree. D3DDEGREE_LINEAR (default) or D3DDEGREE_QUADRATIC
+    this.RS_COLORWRITEENABLE = 168; // per-channel write enable
+    this.RS_TWEENFACTOR = 170; // float tween factor
+    this.RS_BLENDOP = 171; // D3DBLENDOP setting
+    this.RS_POSITIONDEGREE = 172; // NPatch position interpolation degree. D3DDEGREE_LINEAR or D3DDEGREE_CUBIC (default)
+    this.RS_NORMALDEGREE = 173; // NPatch normal interpolation degree. D3DDEGREE_LINEAR (default) or D3DDEGREE_QUADRATIC
     this.RS_SCISSORTESTENABLE = 174;
     this.RS_SLOPESCALEDEPTHBIAS = 175;
     this.RS_ANTIALIASEDLINEENABLE = 176;
-    this.RS_TWOSIDEDSTENCILMODE = 185;      /* BOOL enable/disable 2 sided stenciling */
-    this.RS_CCW_STENCILFAIL = 186;          /* D3DSTENCILOP to do if ccw stencil test fails */
-    this.RS_CCW_STENCILZFAIL = 187;         /* D3DSTENCILOP to do if ccw stencil test passes and Z test fails */
-    this.RS_CCW_STENCILPASS = 188;          /* D3DSTENCILOP to do if both ccw stencil and Z tests pass */
-    this.RS_CCW_STENCILFUNC = 189;          /* D3DCMPFUNC fn.  ccw Stencil Test passes if ((ref & mask) stencilfn (stencil & mask)) is true */
-    this.RS_COLORWRITEENABLE1 = 190;        /* Additional ColorWriteEnables for the devices that support D3DPMISCCAPS_INDEPENDENTWRITEMASKS */
-    this.RS_COLORWRITEENABLE2 = 191;        /* Additional ColorWriteEnables for the devices that support D3DPMISCCAPS_INDEPENDENTWRITEMASKS */
-    this.RS_COLORWRITEENABLE3 = 192;        /* Additional ColorWriteEnables for the devices that support D3DPMISCCAPS_INDEPENDENTWRITEMASKS */
-    this.RS_BLENDFACTOR = 193;              /* D3DCOLOR used for a constant blend factor during alpha blending for devices that support D3DPBLENDCAPS_BLENDFACTOR */
-    this.RS_SRGBWRITEENABLE = 194;          /* Enable rendertarget writes to be DE-linearized to SRGB (for formats that expose D3DUSAGE_QUERY_SRGBWRITE) */
+    this.RS_TWOSIDEDSTENCILMODE = 185; /* BOOL enable/disable 2 sided stenciling */
+    this.RS_CCW_STENCILFAIL = 186; /* D3DSTENCILOP to do if ccw stencil test fails */
+    this.RS_CCW_STENCILZFAIL = 187; /* D3DSTENCILOP to do if ccw stencil test passes and Z test fails */
+    this.RS_CCW_STENCILPASS = 188; /* D3DSTENCILOP to do if both ccw stencil and Z tests pass */
+    this.RS_CCW_STENCILFUNC = 189; /* D3DCMPFUNC fn.  ccw Stencil Test passes if ((ref & mask) stencilfn (stencil & mask)) is true */
+    this.RS_COLORWRITEENABLE1 = 190; /* Additional ColorWriteEnables for the devices that support D3DPMISCCAPS_INDEPENDENTWRITEMASKS */
+    this.RS_COLORWRITEENABLE2 = 191; /* Additional ColorWriteEnables for the devices that support D3DPMISCCAPS_INDEPENDENTWRITEMASKS */
+    this.RS_COLORWRITEENABLE3 = 192; /* Additional ColorWriteEnables for the devices that support D3DPMISCCAPS_INDEPENDENTWRITEMASKS */
+    this.RS_BLENDFACTOR = 193; /* D3DCOLOR used for a constant blend factor during alpha blending for devices that support D3DPBLENDCAPS_BLENDFACTOR */
+    this.RS_SRGBWRITEENABLE = 194; /* Enable rendertarget writes to be DE-linearized to SRGB (for formats that expose D3DUSAGE_QUERY_SRGBWRITE) */
     this.RS_DEPTHBIAS = 195;
     this.RS_SEPARATEALPHABLENDENABLE = 206; /* TRUE to enable a separate blending function for the alpha channel */
-    this.RS_SRCBLENDALPHA = 207;            /* SRC blend factor for the alpha channel when RS_SEPARATEDESTALPHAENABLE is TRUE */
-    this.RS_DESTBLENDALPHA = 208;           /* DST blend factor for the alpha channel when RS_SEPARATEDESTALPHAENABLE is TRUE */
-    this.RS_BLENDOPALPHA = 209;             /* Blending operation for the alpha channel when RS_SEPARATEDESTALPHAENABLE is TRUE */
+    this.RS_SRCBLENDALPHA = 207; /* SRC blend factor for the alpha channel when RS_SEPARATEDESTALPHAENABLE is TRUE */
+    this.RS_DESTBLENDALPHA = 208; /* DST blend factor for the alpha channel when RS_SEPARATEDESTALPHAENABLE is TRUE */
+    this.RS_BLENDOPALPHA = 209; /* Blending operation for the alpha channel when RS_SEPARATEDESTALPHAENABLE is TRUE */
 
     this.CULL_NONE = 1;
     this.CULL_CW = 2;
@@ -302,23 +302,22 @@ function Tw2Device()
         this.depthOffsetState.states[this.RS_DEPTHBIAS] = 0;
         this.depthOffsetState.dirty = false;
 
-        this._blendTable = [
-            -1,                                 // --
-            this.gl.ZERO,                       // D3DBLEND_ZERO
-            this.gl.ONE,                        // D3DBLEND_ONE
-            this.gl.SRC_COLOR,                  // D3DBLEND_SRCCOLOR
-            this.gl.ONE_MINUS_SRC_COLOR,        // D3DBLEND_INVSRCCOLOR
-            this.gl.SRC_ALPHA,                  // D3DBLEND_SRCALPHA
-            this.gl.ONE_MINUS_SRC_ALPHA,        // D3DBLEND_INVSRCALPHA
-            this.gl.DST_ALPHA,                  // D3DBLEND_DESTALPHA
-            this.gl.ONE_MINUS_DST_ALPHA,        // D3DBLEND_INVDESTALPHA
-            this.gl.DST_COLOR,                  // D3DBLEND_DESTCOLOR
-            this.gl.ONE_MINUS_DST_COLOR,        // D3DBLEND_INVDESTCOLOR
-            this.gl.SRC_ALPHA_SATURATE,         // D3DBLEND_SRCALPHASAT
-            -1,                                 // D3DBLEND_BOTHSRCALPHA
-            -1,                                 // D3DBLEND_BOTHINVSRCALPHA
-            this.gl.CONSTANT_COLOR,             // D3DBLEND_BLENDFACTOR
-            this.gl.ONE_MINUS_CONSTANT_COLOR    // D3DBLEND_INVBLENDFACTOR
+        this._blendTable = [-1, // --
+            this.gl.ZERO, // D3DBLEND_ZERO
+            this.gl.ONE, // D3DBLEND_ONE
+            this.gl.SRC_COLOR, // D3DBLEND_SRCCOLOR
+            this.gl.ONE_MINUS_SRC_COLOR, // D3DBLEND_INVSRCCOLOR
+            this.gl.SRC_ALPHA, // D3DBLEND_SRCALPHA
+            this.gl.ONE_MINUS_SRC_ALPHA, // D3DBLEND_INVSRCALPHA
+            this.gl.DST_ALPHA, // D3DBLEND_DESTALPHA
+            this.gl.ONE_MINUS_DST_ALPHA, // D3DBLEND_INVDESTALPHA
+            this.gl.DST_COLOR, // D3DBLEND_DESTCOLOR
+            this.gl.ONE_MINUS_DST_COLOR, // D3DBLEND_INVDESTCOLOR
+            this.gl.SRC_ALPHA_SATURATE, // D3DBLEND_SRCALPHASAT
+            -1, // D3DBLEND_BOTHSRCALPHA
+            -1, // D3DBLEND_BOTHINVSRCALPHA
+            this.gl.CONSTANT_COLOR, // D3DBLEND_BLENDFACTOR
+            this.gl.ONE_MINUS_CONSTANT_COLOR // D3DBLEND_INVBLENDFACTOR
         ];
 
         this._shadowStateBuffer = new Float32Array(24);
@@ -450,7 +449,7 @@ function Tw2Device()
         {
             return;
         }
-        device.gl.bindBuffer(device.gl.ARRAY_BUFFER, this._quadBuffer);
+        this.gl.bindBuffer(this.gl.ARRAY_BUFFER, this._quadBuffer);
 
         for (var pass = 0; pass < effect.GetPassCount(); ++pass)
         {
@@ -460,7 +459,7 @@ function Tw2Device()
                 return false;
             }
             this.ApplyShadowState();
-            device.gl.drawArrays(device.gl.TRIANGLE_STRIP, 0, 4);
+            this.gl.drawArrays(this.gl.TRIANGLE_STRIP, 0, 4);
         }
     };
 
@@ -515,7 +514,7 @@ function Tw2Device()
             vec[3] = 1;
         }
 
-        this.gl.bindBuffer(device.gl.ARRAY_BUFFER, this._cameraQuadBuffer);
+        this.gl.bindBuffer(this.gl.ARRAY_BUFFER, this._cameraQuadBuffer);
         this.gl.bufferData(this.gl.ARRAY_BUFFER, vertices, this.gl.STATIC_DRAW);
 
         for (var pass = 0; pass < effect.GetPassCount(); ++pass)
@@ -526,7 +525,7 @@ function Tw2Device()
                 return false;
             }
             this.ApplyShadowState();
-            device.gl.drawArrays(device.gl.TRIANGLE_STRIP, 0, 4);
+            this.gl.drawArrays(this.gl.TRIANGLE_STRIP, 0, 4);
         }
     };
 
@@ -750,11 +749,11 @@ function Tw2Device()
                     var invertedAlphaTest = 1;
                     var alphaTestRef = -this.alphaTestState.states[this.RS_ALPHAREF] - 1;
                     break;
-                /*case this.CMP_NOTEQUAL:
-                 var alphaTestFunc = 1;
-                 var invertedAlphaTest = 1;
-                 var alphaTestRef = this.alphaTestState.states[this.RS_ALPHAREF];
-                 break;*/
+                    /*case this.CMP_NOTEQUAL:
+                     var alphaTestFunc = 1;
+                     var invertedAlphaTest = 1;
+                     var alphaTestRef = this.alphaTestState.states[this.RS_ALPHAREF];
+                     break;*/
                 case this.CMP_GREATEREQUAL:
                     var alphaTestFunc = 0;
                     var invertedAlphaTest = 1;
@@ -767,7 +766,7 @@ function Tw2Device()
                     break;
             }
             var clipPlaneEnable = 0;
-            device.gl.uniform4f(
+            this.gl.uniform4f(
                 this.shadowHandles.shadowStateInt,
                 invertedAlphaTest,
                 alphaTestRef,
@@ -876,15 +875,15 @@ function Tw2Device()
     {
         if (this._whiteTexture == null)
         {
-            this._whiteTexture = device.gl.createTexture();
-            device.gl.bindTexture(device.gl.TEXTURE_2D, this._whiteTexture);
-            device.gl.texImage2D(device.gl.TEXTURE_2D, 0, device.gl.RGBA, 1, 1, 0, device.gl.RGBA, device.gl.UNSIGNED_BYTE, new Uint8Array([0, 0, 0, 0]));
-            device.gl.texParameteri(device.gl.TEXTURE_2D, device.gl.TEXTURE_WRAP_S, device.gl.CLAMP_TO_EDGE);
-            device.gl.texParameteri(device.gl.TEXTURE_2D, device.gl.TEXTURE_WRAP_T, device.gl.CLAMP_TO_EDGE);
-            device.gl.texParameteri(device.gl.TEXTURE_2D, device.gl.TEXTURE_MAG_FILTER, device.gl.NEAREST);
-            device.gl.texParameteri(device.gl.TEXTURE_2D, device.gl.TEXTURE_MIN_FILTER, device.gl.NEAREST);
-            //device.gl.generateMipmap(device.gl.TEXTURE_2D);
-            device.gl.bindTexture(device.gl.TEXTURE_2D, null);
+            this._whiteTexture = this.gl.createTexture();
+            this.gl.bindTexture(this.gl.TEXTURE_2D, this._whiteTexture);
+            this.gl.texImage2D(this.gl.TEXTURE_2D, 0, this.gl.RGBA, 1, 1, 0, this.gl.RGBA, this.gl.UNSIGNED_BYTE, new Uint8Array([0, 0, 0, 0]));
+            this.gl.texParameteri(this.gl.TEXTURE_2D, this.gl.TEXTURE_WRAP_S, this.gl.CLAMP_TO_EDGE);
+            this.gl.texParameteri(this.gl.TEXTURE_2D, this.gl.TEXTURE_WRAP_T, this.gl.CLAMP_TO_EDGE);
+            this.gl.texParameteri(this.gl.TEXTURE_2D, this.gl.TEXTURE_MAG_FILTER, this.gl.NEAREST);
+            this.gl.texParameteri(this.gl.TEXTURE_2D, this.gl.TEXTURE_MIN_FILTER, this.gl.NEAREST);
+            //this.gl.generateMipmap(this.gl.TEXTURE_2D);
+            this.gl.bindTexture(this.gl.TEXTURE_2D, null);
         }
         return this._whiteTexture;
     };
@@ -899,18 +898,18 @@ function Tw2Device()
     {
         if (this._whiteCube == null)
         {
-            this._whiteCube = device.gl.createTexture();
-            device.gl.bindTexture(device.gl.TEXTURE_CUBE_MAP, this._whiteCube);
+            this._whiteCube = this.gl.createTexture();
+            this.gl.bindTexture(this.gl.TEXTURE_CUBE_MAP, this._whiteCube);
             for (var j = 0; j < 6; ++j)
             {
-                device.gl.texImage2D(device.gl.TEXTURE_CUBE_MAP_POSITIVE_X + j, 0, device.gl.RGBA, 1, 1, 0, device.gl.RGBA, device.gl.UNSIGNED_BYTE, new Uint8Array([0, 0, 0, 0]));
+                this.gl.texImage2D(this.gl.TEXTURE_CUBE_MAP_POSITIVE_X + j, 0, this.gl.RGBA, 1, 1, 0, this.gl.RGBA, this.gl.UNSIGNED_BYTE, new Uint8Array([0, 0, 0, 0]));
             }
-            device.gl.texParameteri(device.gl.TEXTURE_CUBE_MAP, device.gl.TEXTURE_WRAP_S, device.gl.CLAMP_TO_EDGE);
-            device.gl.texParameteri(device.gl.TEXTURE_CUBE_MAP, device.gl.TEXTURE_WRAP_T, device.gl.CLAMP_TO_EDGE);
-            device.gl.texParameteri(device.gl.TEXTURE_CUBE_MAP, device.gl.TEXTURE_MAG_FILTER, device.gl.NEAREST);
-            device.gl.texParameteri(device.gl.TEXTURE_CUBE_MAP, device.gl.TEXTURE_MIN_FILTER, device.gl.NEAREST);
-            //device.gl.generateMipmap(device.gl.TEXTURE_CUBE_MAP);
-            device.gl.bindTexture(device.gl.TEXTURE_CUBE_MAP, null);
+            this.gl.texParameteri(this.gl.TEXTURE_CUBE_MAP, this.gl.TEXTURE_WRAP_S, this.gl.CLAMP_TO_EDGE);
+            this.gl.texParameteri(this.gl.TEXTURE_CUBE_MAP, this.gl.TEXTURE_WRAP_T, this.gl.CLAMP_TO_EDGE);
+            this.gl.texParameteri(this.gl.TEXTURE_CUBE_MAP, this.gl.TEXTURE_MAG_FILTER, this.gl.NEAREST);
+            this.gl.texParameteri(this.gl.TEXTURE_CUBE_MAP, this.gl.TEXTURE_MIN_FILTER, this.gl.NEAREST);
+            //this.gl.generateMipmap(this.gl.TEXTURE_CUBE_MAP);
+            this.gl.bindTexture(this.gl.TEXTURE_CUBE_MAP, null);
         }
         return this._whiteCube;
     };

--- a/src/core/Tw2ObjectReader.js
+++ b/src/core/Tw2ObjectReader.js
@@ -1,13 +1,18 @@
 /**
  * Tw2ObjectReader
- * TODO: Identify if @property _inputStack @property _initializeObject and @property _ids should be defined here
  * @param xmlNode
  * @property xmlNode
+ * @property {null|Array} _inputStack
+ * @property {null|Array} _initializeObjects
+ * @property {null|Array} _ids
  * @constructor
  */
 function Tw2ObjectReader(xmlNode)
 {
     this.xmlNode = xmlNode;
+    this._inputStack = null;
+    this._initializeObjects = null;
+    this._ids = null;
 }
 
 /**

--- a/src/curves/Tw2EventCurve.js
+++ b/src/curves/Tw2EventCurve.js
@@ -14,7 +14,7 @@ function Tw2EventKey()
 /**
  * Tw2EventCurve
  * @property {string} name
- * @property value
+ * @property {string} value
  * @property {Array.<Tw2EventKey>} keys
  * @property {number} extrapolation
  * @property {number} _length
@@ -35,13 +35,12 @@ function Tw2EventCurve()
 
 /**
  * Compares two curve keys' time properties
- * TODO: This function is called 'Compare' in other Tw2Curves, check to see if it can be refactored.
  * @param {Tw2EventKey} a
  * @param {Tw2EventKey} b
  * @returns {number}
  * @method
  */
-Tw2EventCurve.KeySort = function(a, b)
+Tw2EventCurve.Compare = function(a, b)
 {
     if (a.time < b.time)
     {
@@ -60,7 +59,7 @@ Tw2EventCurve.KeySort = function(a, b)
  */
 Tw2EventCurve.prototype.Initialize = function()
 {
-    this.keys.sort(Tw2EventCurve.KeySort);
+    this.keys.sort(Tw2EventCurve.Compare);
     this._length = 0;
     if (this.keys.length)
     {

--- a/src/curves/Tw2Vector2Curve.js
+++ b/src/curves/Tw2Vector2Curve.js
@@ -129,7 +129,6 @@ Tw2Vector2Curve.prototype.UpdateValue = function(time)
 
 /**
  * Gets a value at a specific time
- * TODO: the variable `i` is used before it has been initialized
  * @param {number} time
  * @param {Float32Array} value - vec2 array
  * @returns {Float32Array} vec2 array
@@ -180,7 +179,7 @@ Tw2Vector2Curve.prototype.GetValueAt = function(time, value)
     {
         return this.Interpolate(time, this.keys[this.keys.length - 1], null, value);
     }
-    var endKey = this.keys[i + 1]; // <----------------------------------------- `i` is not yet initialized
+    var endKey;
     for (var i = 0; i + 1 < this.keys.length; ++i)
     {
         startKey = this.keys[i];

--- a/src/curves/Tw2Vector3Curve.js
+++ b/src/curves/Tw2Vector3Curve.js
@@ -183,7 +183,7 @@ Tw2Vector3Curve.prototype.GetValueAt = function(time, value)
     {
         return this.Interpolate(time, this.keys[this.keys.length - 1], null, value);
     }
-    var endKey = this.keys[i + 1]; // <----------------------------------------- `i` is not yet initialized
+    var endKey;
     for (var i = 0; i + 1 < this.keys.length; ++i)
     {
         startKey = this.keys[i];

--- a/src/eve/EveSpaceObject.js
+++ b/src/eve/EveSpaceObject.js
@@ -131,7 +131,7 @@ EveSpaceObject.prototype.UpdateLod = function(frustum)
 
     if (frustum.IsSphereVisible(center, this.boundingSphereRadius))
     {
-        if (frustum.GetPixelSizeAccross(center, this.boundingSphereRadius) < 100)
+        if (frustum.GetPixelSizeAcross(center, this.boundingSphereRadius) < 100)
         {
             this.lod = 1;
         }

--- a/src/eve/EveStretch.js
+++ b/src/eve/EveStretch.js
@@ -29,7 +29,7 @@ EveStretch.prototype.Update = function (dt) {
     }
     this._time += dt;
     if (this.source) {
-        this.source.GetValueAt(t, this._sourcePosition);
+        this.source.GetValueAt(this._time, this._sourcePosition);
     }
     else if (this._useTransformsForStretch) {
         this._sourcePosition[0] = this._sourceTransform[12];
@@ -37,7 +37,7 @@ EveStretch.prototype.Update = function (dt) {
         this._sourcePosition[2] = this._sourceTransform[14];
     }
     if (this.dest) {
-        this.source.GetValueAt(t, this._destinationPosition);
+        this.source.GetValueAt(this._time, this._destinationPosition);
     }
     var directionVec = vec3.subtract(this._destinationPosition, this._sourcePosition, EveStretch._tempVec3[0]);
     var scalingLength = vec3.length(directionVec);


### PR DESCRIPTION
- Changed the `this.source.GetValueAt` argument `t` to `this._time`in the `Update` @prototype in `EveStretch`
- Refactored @prototype `KeySort` to `Compare` to bring it inline with other curve compare functions in `Tw2EventCurve`
- Fixed typo in `frustum` method call `GetPixelSizeAcross` in `EveSpaceObject`
- Removed unnecessary variable definition `Tw2Vector2Curve`
- Removed unnecessary variable definition `Tw2Vector3Curve`
- Replaced references to the `device` @variable with `this` in `Tw2Device`
- Added `_inputStack`, `_initializeObjects` and `_ids` @properties to `Tw2ObjectReader`