### PR TITLE
Renamed Tw2QuaternionKey to Tw2QuaternionKey2

### DIFF
--- a/src/curves/Tw2QuaternionCurve.js
+++ b/src/curves/Tw2QuaternionCurve.js
@@ -1,5 +1,5 @@
 /**
- * Tw2QuaternionKey
+ * Tw2QuaternionKey2
  * @property {number} time
  * @property {quat4} value
  * @property {quat4} leftTangent
@@ -7,7 +7,7 @@
  * @property {number} interpolation
  * @constructor
  */
-function Tw2QuaternionKey()
+function Tw2QuaternionKey2()
 {
     this.time = 0;
     this.value = quat4.create();


### PR DESCRIPTION
- Renamed @constructor `Tw2QuaternionKey` to `Tw2QuaternionKey2`
- This constructor matches the newer style Tr2 curve keys who's names are suffixed with `2` (There is an existing constructor with the same name matching the older key style in the `Tw2RotationCurve.js` file)