### PR TITLE
Added GetResources Methods. Updated EveCurveLineSet and Tw2Resource

### DIFF
--- a/src/core/Tw2AnimationController.js
+++ b/src/core/Tw2AnimationController.js
@@ -131,6 +131,29 @@ function Tw2AnimationController(geometryResource)
 }
 
 /**
+ * Gets all animation controller res objects
+ * @param {Array} [out=[]] - Optional receiving array
+ * @returns {Array.<Tw2EffectRes|Tw2TextureRes|Tw2GeometryRes>} [out]
+ */
+
+Tw2AnimationController.prototype.GetResources = function(out)
+{
+    if (out === undefined)
+    {
+        out = [];
+    }
+
+    for (var i = 0; i < this.geometryResources.length; i++)
+    {
+        if (out.indexOf(this.geometryResources[i]) === -1)
+        {
+            out.push(this.geometryResources[i]);
+        }
+    }
+    return out;
+}
+
+/**
  * Clears any existing resources and loads the supplied geometry resource
  * @param {Tw2GeometryRes} geometryResource
  * @prototype
@@ -595,7 +618,7 @@ Tw2AnimationController.prototype.StopAnimation = function(names)
     }
 
     var toStop = {};
-    
+
     for (var n = 0; n < names.length; n++)
     {
         toStop[names[n]] = true;
@@ -655,7 +678,7 @@ Tw2AnimationController.prototype.StopAllAnimationsExcept = function(names)
     }
 
     var keepAnimating = {};
-    
+
     for (var n = 0; n < names.length; n++)
     {
         keepAnimating[names[n]] = true;

--- a/src/core/Tw2Effect.js
+++ b/src/core/Tw2Effect.js
@@ -138,6 +138,40 @@ Tw2Effect.prototype.Initialize = function()
 };
 
 /**
+ * Gets all effect res objects
+ * @param {Array} [out=[]] - Optional receiving array
+ * @returns {Array.<Tw2EffectRes|Tw2TextureRes>} [out]
+ */
+Tw2Effect.prototype.GetResources = function(out)
+{
+    if (out === undefined)
+    {
+        out = [];
+    }
+
+    if (this.effectRes !== null)
+    {
+        if (out.indexOf(this.effectRes) === -1)
+        {
+            out.push(this.effectRes);
+        }
+    }
+
+    for (var param in this.parameters)
+    {
+        if (this.parameters.hasOwnProperty(param))
+        {
+            if (this.parameters[param] instanceof Tw2TextureParameter)
+            {
+                this.parameters[param].GetResource(out);
+            }
+        }
+    }
+
+    return out;
+}
+
+/**
  * Returns the Tw2Effect's resource object
  * @prototype
  */

--- a/src/core/Tw2Mesh.js
+++ b/src/core/Tw2Mesh.js
@@ -99,6 +99,42 @@ Tw2Mesh.prototype.Initialize = function()
 };
 
 /**
+ * Gets Mesh res Objects
+ * @param {Array} [out=[]] - Optional receiving array
+ * @returns {Array.<Tw2EffectRes|Tw2TextureRes|Tw2GeometryRes>} [out]
+ */
+Tw2Mesh.prototype.GetResources = function(out)
+{
+    if (out === undefined)
+    {
+        out = [];
+    }
+
+    var self = this;
+
+    if (out.indexOf(this.geometryResource) === -1)
+    {
+        out.push(this.geometryResource);
+    }
+
+    function getAreaResources(areaName, out)
+    {
+        for (var i = 0; i < self[areaName].length; i++)
+        {
+            self[areaName][i].effect.GetResources(out);
+        }
+    }
+
+    getAreaResources('additiveAreas', out);
+    getAreaResources('decalAreas', out);
+    getAreaResources('depthAreas', out);
+    getAreaResources('opaqueAreas', out);
+    getAreaResources('pickableAreas', out);
+    getAreaResources('transparentAreas', out);
+    return out;
+}
+
+/**
  * Gets render batches from a mesh area array and commits them to an accumulator
  * @param {Array.<Tw2MeshArea>} areas
  * @param {RenderMode} mode

--- a/src/core/Tw2Resource.js
+++ b/src/core/Tw2Resource.js
@@ -12,6 +12,9 @@
  * @property {Array} _notifications
  * @property {number} activeFrame
  * @property {number} doNotPurge
+ * @property {null|Function} _onLoadStarted - optional callback fired on res loading: callback(this)
+ * @property {null|Function} _onLoadFinished - optional callback fired on res loaded: callback(this, success)
+ * @property {null|Function} _onLoadPrepareFinished - optional callback fired on res prepare finish: callback(this, success)
  * @constructor
  */
 function Tw2Resource()
@@ -23,6 +26,9 @@ function Tw2Resource()
     this._notifications = [];
     this.activeFrame = 0;
     this.doNotPurge = 0;
+    this._onLoadStarted = null;
+    this._onLoadFinished = null;
+    this._onPrepareFinished = null;
 }
 
 /**
@@ -64,9 +70,15 @@ Tw2Resource.prototype.IsPurged = function()
 Tw2Resource.prototype.LoadStarted = function()
 {
     this._isLoading = true;
+
     for (var i = 0; i < this._notifications.length; ++i)
     {
         this._notifications[i].ReleaseCachedData(this);
+    }
+
+    if (this._onLoadStarted)
+    {
+        this._onLoadStarted(this);
     }
 };
 
@@ -78,9 +90,15 @@ Tw2Resource.prototype.LoadStarted = function()
 Tw2Resource.prototype.LoadFinished = function(success)
 {
     this._isLoading = false;
+
     if (!success)
     {
         this._isGood = false;
+    }
+
+    if (this._onLoadFinished)
+    {
+        this._onLoadFinished(this, success);
     }
 };
 
@@ -93,9 +111,15 @@ Tw2Resource.prototype.PrepareFinished = function(success)
 {
     this._isLoading = false;
     this._isGood = success;
+
     for (var i = 0; i < this._notifications.length; ++i)
     {
         this._notifications[i].RebuildCachedData(this);
+    }
+
+    if(this._onPrepareFinished)
+    {
+        this._onPrepareFinished(this, success);
     }
 };
 

--- a/src/core/Tw2TextureParameter.js
+++ b/src/core/Tw2TextureParameter.js
@@ -47,6 +47,29 @@ function Tw2TextureParameter(name, texturePath)
 }
 
 /**
+ * Gets texture res object
+ * @param {Array} [out=[]] - Optional receiving array
+ * @returns {Array.<Tw2TextureRes>} [out]
+ */
+Tw2TextureParameter.prototype.GetResource = function(out)
+{
+    if (out === undefined)
+    {
+        out = [];
+    }
+
+    if (this.textureRes !== null)
+    {
+        if (out.indexOf(this.textureRes) === -1)
+        {
+            out.push(this.textureRes);
+        }
+    }
+
+    return out;
+}
+
+/**
  * Sets the texture's resource path
  * @param {string} texturePath
  * @constructor
@@ -70,7 +93,7 @@ Tw2TextureParameter.prototype.Initialize = function()
     {
         this.textureRes = resMan.GetResource(this.resourcePath);
     }
-    
+
     if (this.useAllOverrides)
     {
         this._sampler = new Tw2SamplerState();
@@ -149,12 +172,12 @@ Tw2TextureParameter.prototype.Apply = function(stage, sampler, slices)
  * Get Value
  * @return {string}
  */
- Tw2TextureParameter.prototype.GetValue = function()
- {
-     if (this.textureRes)
-     {
-         return this.textureRes.path;
-     }
-     
-     return this.resourcePath;
- }
+Tw2TextureParameter.prototype.GetValue = function()
+{
+    if (this.textureRes)
+    {
+        return this.textureRes.path;
+    }
+
+    return this.resourcePath;
+}

--- a/src/core/Tw2TransformParameter.js
+++ b/src/core/Tw2TransformParameter.js
@@ -49,7 +49,7 @@ Tw2TransformParameter.prototype.OnModified = function()
     var rotationCenterInv = mat4.create();
     mat4.identity(rotationCenterInv);
     mat4.translate(rotationCenterInv, [-this.rotationCenter[0], -this.rotationCenter[1], -this.rotationCenter[2]]);
-    
+
     var rotation = mat4.create();
     rotation[0] = 1.0 - 2.0 * this.rotation[1] * this.rotation[1] - 2 * this.rotation[2] * this.rotation[2];
     rotation[4] = 2 * this.rotation[0] * this.rotation[1] - 2 * this.rotation[2] * this.rotation[3];

--- a/src/eve/EveBoosterSet.js
+++ b/src/eve/EveBoosterSet.js
@@ -72,6 +72,31 @@ EveBoosterSet.prototype.Initialize = function()
 };
 
 /**
+ * Gets booster set res objects
+ * @param {Array} [out=[]] - Optional receiving array
+ * @returns {Array.<Tw2EffectRes|Tw2TextureRes>} [out]
+ */
+EveBoosterSet.prototype.GetResources = function(out)
+{
+    if (out === undefined)
+    {
+        out = [];
+    }
+
+    if (this.effect !== null)
+    {
+        this.effect.GetResources(out);
+    }
+
+    if (this.glows !== null && this.glows.effect !== null)
+    {
+        this.glows.effect.GetResources(out);
+    }
+
+    return out;
+}
+
+/**
  * Clears the booster set
  */
 EveBoosterSet.prototype.Clear = function()

--- a/src/eve/EveChildMesh.js
+++ b/src/eve/EveChildMesh.js
@@ -42,7 +42,7 @@ function EveChildMesh()
  * Updates mesh transform
  * @param {mat4} parentTransform
  */
-EveChildMesh.prototype.Update = function (parentTransform)
+EveChildMesh.prototype.Update = function(parentTransform)
 {
     if (this.useSRT)
     {
@@ -64,7 +64,7 @@ EveChildMesh.prototype.Update = function (parentTransform)
  * @param {Tw2BatchAccumulator} accumulator
  * @param {Tw2PerObjectData} perObjectData
  */
-EveChildMesh.prototype.GetBatches = function (mode, accumulator, perObjectData)
+EveChildMesh.prototype.GetBatches = function(mode, accumulator, perObjectData)
 {
     if (!this.display || !this.mesh)
     {
@@ -109,3 +109,25 @@ EveChildMesh.prototype.GetBatches = function (mode, accumulator, perObjectData)
     this.mesh.GetBatches(mode, accumulator, this._perObjectData);
 
 };
+
+
+
+/**
+ * Gets child mesh res objects
+ * @param {Array} [out=[]] - Optional receiving array
+ * @returns {Array.<Tw2EffectRes|Tw2TextureRes|Tw2GeometryRes>} [out]
+ */
+EveChildMesh.prototype.GetResources = function(out)
+{
+    if (out === undefined)
+    {
+        out = [];
+    }
+
+    if (this.mesh !== null)
+    {
+        this.mesh.GetResources(out);
+    }
+
+    return out;
+}

--- a/src/eve/EveCurveLineSet.js
+++ b/src/eve/EveCurveLineSet.js
@@ -266,7 +266,7 @@ EveCurveLineSet.prototype.AddSpheredLineSph = function(startPosition, startColor
     vec3.add(startPnt, center);
     vec3.add(endPnt, center);
     // add it
-    return this.AddSpheredLineCrt(startPnt, startColor, endPnt, endColor, lineWidth);
+    return this.AddSpheredLineCrt(startPnt, startColor, endPnt, endColor, center, lineWidth);
 };
 
 /**

--- a/src/eve/EveCurveLineSet.js
+++ b/src/eve/EveCurveLineSet.js
@@ -1,583 +1,811 @@
+/**
+ * vec3 Hermite
+ * @param out
+ * @param v1
+ * @param t1
+ * @param v2
+ * @param t2
+ * @param s
+ * @returns {*}
+ */
+function vec3Hermite(out, v1, t1, v2, t2, s)
+{
+    var k3 = 2 * s * s * s - 3 * s * s + 1;
+    var k2 = -2 * s * s * s + 3 * s * s;
+    var k1 = s * s * s - 2 * s * s + s;
+    var k0 = s * s * s - s * s;
+
+    out[0] = k3 * v1[0] + k2 * v2[0] + k1 * t1[0] + k0 * t2[0];
+    out[1] = k3 * v1[1] + k2 * v2[1] + k1 * t1[1] + k0 * t2[1];
+    out[2] = k3 * v1[2] + k2 * v2[2] + k1 * t1[2] + k0 * t2[2];
+    return out;
+}
+
+/**
+ * EveCurveLineSet
+ * @param {String} name
+ * @param {Boolean} display
+ * @param {Boolean} disableDepth
+ * @param {Number} lineWidthFactor
+ * @param {Array} lines
+ * @param {Array} emptyLineID
+ * @param {vec3} translation
+ * @param {quat4} rotation
+ * @param {vec3} scaling
+ * @param {mat4} transform
+ * @param {Tw2Effect} lineEffect
+ * @param {null|Tw2Effect} pickEffect
+ * @param {Boolean} additive
+ * @param {Tw2PerObjectData} perObjectData
+ * @param {Number} _vertexSize
+ * @param {WebGLBuffer} _vertexBuffer
+ * @param {Number} _vertexBufferSize
+ * @param {Tw2VertexDeclaration} declaration
+ * @constructor
+ */
 function EveCurveLineSet()
 {
-    this.lineEffect = new Tw2Effect();
-    this.lineEffect.effectFilePath = "res:/Graphics/Effect/Managed/Space/SpecialFX/Lines3D.fx";
-    this.lineEffect.Initialize();
-    this.pickEffect = null;
+    this.name = '';
+    this.display = true;
+    this.disableDepth = false;
     this.lineWidthFactor = 1;
-    this.additive = false;
+    this.lines = [];
+    this.emptyLineID = [];
+
     this.translation = vec3.create();
     this.rotation = quat4.create([0, 0, 0, 1]);
     this.scaling = vec3.create([1, 1, 1]);
-    this.name = '';
-    this.display = true;
-    this.depthOffset = 0;
+    this.transform = mat4.identity(mat4.create());
 
-    var perObjectData = new Tw2PerObjectData();
-    perObjectData.perObjectVSData = new Tw2RawData();
-    perObjectData.perObjectVSData.Declare('WorldMat', 16);
-    perObjectData.perObjectVSData.Create();
+    this.lineEffect = new Tw2Effect();
+    this.lineEffect.effectFilePath = "res:/Graphics/Effect/Managed/Space/SpecialFX/Lines3D.fx";
+    this.lineEffect.parameters['TexMap'] = new Tw2TextureParameter('TexMap', 'res:/texture/global/white.dds.0.png');
+    this.lineEffect.parameters['OverlayTexMap'] = new Tw2TextureParameter('OverlayTexMap', 'res:/texture/global/white.dds.0.png');
+    this.lineEffect.Initialize();
+    this.pickEffect = null;
+    this.additive = false;
 
-    perObjectData.perObjectPSData = new Tw2RawData();
-    perObjectData.perObjectPSData.Declare('WorldMat', 16);
-    perObjectData.perObjectPSData.Create();
+    this.perObjectData = new Tw2PerObjectData();
+    this.perObjectData.perObjectVSData = new Tw2RawData();
+    this.perObjectData.perObjectVSData.Declare('WorldMat', 16);
+    this.perObjectData.perObjectVSData.Create();
+    this.perObjectData.perObjectPSData = new Tw2RawData();
+    this.perObjectData.perObjectPSData.Declare('WorldMat', 16);
+    this.perObjectData.perObjectPSData.Create();
 
-    var transform = mat4.identity(mat4.create());
-    var lines = [];
-    var emptyLineID = [];
+    this._vertexSize = 26;
+    this._vertexBuffer = null;
+    this._vertexBufferSize = 0;
+    this.declaration = new Tw2VertexDeclaration();
+    this.declaration.elements.push(new Tw2VertexElement(Tw2VertexDeclaration.DECL_POSITION, 0, device.gl.FLOAT, 3, 0));
+    this.declaration.elements.push(new Tw2VertexElement(Tw2VertexDeclaration.DECL_TEXCOORD, 0, device.gl.FLOAT, 4, 12));
+    this.declaration.elements.push(new Tw2VertexElement(Tw2VertexDeclaration.DECL_TEXCOORD, 1, device.gl.FLOAT, 4, 28));
+    this.declaration.elements.push(new Tw2VertexElement(Tw2VertexDeclaration.DECL_TEXCOORD, 2, device.gl.FLOAT, 3, 44));
+    this.declaration.elements.push(new Tw2VertexElement(Tw2VertexDeclaration.DECL_COLOR, 0, device.gl.FLOAT, 4, 56));
+    this.declaration.elements.push(new Tw2VertexElement(Tw2VertexDeclaration.DECL_COLOR, 1, device.gl.FLOAT, 4, 72));
+    this.declaration.elements.push(new Tw2VertexElement(Tw2VertexDeclaration.DECL_COLOR, 2, device.gl.FLOAT, 4, 88));
+    this.declaration.stride = 4 * this._vertexSize;
+    this.declaration.RebuildHash();
+}
 
-    this.Initialize = function()
+/**
+ * Initializes the Curve line set
+ */
+this.Initialize = function()
+{
+    mat4.identity(this.transform);
+    mat4.translate(this.transform, this.translation);
+    var rotationTransform = mat4.transpose(quat4.toMat4(this.rotation, mat4.create()));
+    mat4.multiply(this.transform, rotationTransform, this.transform);
+    mat4.scale(this.transform, this.scaling);
+};
+
+/**
+ * Adds a line
+ * @param line
+ * @returns {Number} Line index
+ * @private
+ */
+EveCurveLineSet.prototype._addLine = function(line)
+{
+    if (this.emptyLineID.length)
     {
-        mat4.identity(transform);
-        mat4.translate(transform, this.translation);
-        var rotationTransform = mat4.transpose(quat4.toMat4(this.rotation, mat4.create()));
-        mat4.multiply(transform, rotationTransform, transform);
-        mat4.scale(transform, this.scaling);
-    };
-
-    var LINETYPE_INVALID = 0;
-    var LINETYPE_STRAIGHT = 1;
-    var LINETYPE_SPHERED = 2;
-    var LINETYPE_CURVED = 3;
-
-    function addLine(line)
-    {
-        if (emptyLineID.length)
-        {
-            var index = emptyLineID.pop();
-            lines[index] = line;
-            return index;
-        }
-        lines.push(line);
-        return lines.length - 1;
+        var index = this.emptyLineID.pop();
+        this.lines[index] = line;
+        return index;
     }
-    this.AddStraightLine = function(startPosition, startColor, endPosition, endColor, lineWidth)
-    {
-        var line = {
-            type: LINETYPE_STRAIGHT,
-            position1: startPosition,
-            color1: startColor,
-            position2: endPosition,
-            color2: endColor,
-            intermediatePosition: [0, 0, 0],
-            width: lineWidth,
-            multiColor: [0, 0, 0, 0],
-            multiColorBorder: -1,
-            overlayColor: [0, 0, 0, 0],
-            animationSpeed: 0,
-            animationScale: 1,
-            numOfSegments: 1
-        };
-        return addLine(line)
+    this.lines.push(line);
+    return this.lines.length - 1;
+};
+
+/**
+ * Adds a straight line
+ * @param {vec3} startPosition
+ * @param {quat3} startColor
+ * @param {vec3} endPosition
+ * @param {quat4} endColor
+ * @param {Number} lineWidth
+ * @returns {Number} line index
+ */
+EveCurveLineSet.prototype.AddStraightLine = function(startPosition, startColor, endPosition, endColor, lineWidth)
+{
+    var line = {
+        type: EveCurveLineSet.LINETYPE_STRAIGHT,
+        position1: startPosition,
+        color1: startColor,
+        position2: endPosition,
+        color2: endColor,
+        intermediatePosition: [0, 0, 0],
+        width: lineWidth,
+        multiColor: [0, 0, 0, 0],
+        multiColorBorder: -1,
+        overlayColor: [0, 0, 0, 0],
+        animationSpeed: 0,
+        animationScale: 1,
+        numOfSegments: 1
     };
-    this.AddCurvedLineCrt = function(startPosition, startColor, endPosition, endColor, middle, lineWidth)
-    {
-        var line = {
-            type: LINETYPE_CURVED,
-            position1: startPosition,
-            color1: startColor,
-            position2: endPosition,
-            color2: endColor,
-            intermediatePosition: middle,
-            width: lineWidth,
-            multiColor: [0, 0, 0, 0],
-            multiColorBorder: -1,
-            overlayColor: [0, 0, 0, 0],
-            animationSpeed: 0,
-            animationScale: 1,
-            numOfSegments: 20
-        };
-        return addLine(line)
+    return this._addLine(line)
+};
+
+/**
+ * AddCurvedLineCrt
+ * @param {vec3} startPosition
+ * @param {quat4} startColor
+ * @param {vec3} endPosition
+ * @param {quat4} endColor
+ * @param {vec3} middle
+ * @param {Number} lineWidth
+ * @returns {Number} line index
+ */
+EveCurveLineSet.prototype.AddCurvedLineCrt = function(startPosition, startColor, endPosition, endColor, middle, lineWidth)
+{
+    var line = {
+        type: EveCurveLineSet.LINETYPE_CURVED,
+        position1: startPosition,
+        color1: startColor,
+        position2: endPosition,
+        color2: endColor,
+        intermediatePosition: middle,
+        width: lineWidth,
+        multiColor: [0, 0, 0, 0],
+        multiColorBorder: -1,
+        overlayColor: [0, 0, 0, 0],
+        animationSpeed: 0,
+        animationScale: 1,
+        numOfSegments: 20
     };
-    this.AddCurvedLineSph = function(startPosition, startColor, endPosition, endColor, center, middle, lineWidth)
-    {
-        var phi1 = startPosition.x;
-        var theta1 = startPosition.y;
-        var radius1 = startPosition.z;
-        var phi2 = endPosition.x;
-        var theta2 = endPosition.y;
-        var radius2 = endPosition.z;
-        var phiM = middle.x;
-        var thetaM = middle.y;
-        var radiusM = middle.z;
-        // is given in spherical coords, so convert them into cartesian
-        var startPnt = [radius1 * Math.sin(phi1) * Math.sin(theta1), radius1 * Math.cos(theta1), radius1 * Math.cos(phi1) * Math.sin(theta1)];
-        var endPnt = [radius2 * Math.sin(phi2) * Math.sin(theta2), radius2 * Math.cos(theta2), radius2 * Math.cos(phi2) * Math.sin(theta2)];
-        var middlePnt = [radiusM * Math.sin(phiM) * Math.sin(thetaM), radiusM * Math.cos(thetaM), radiusM * Math.cos(phiM) * Math.sin(thetaM)];
-        // dont forget center!
-        vec3.add(startPnt, center);
-        vec3.add(endPnt, center);
-        vec3.add(middlePnt, center);
-        // add it
-        return this.AddCurvedLineCrt(startPnt, startColor, endPnt, endColor, middlePnt, lineWidth);
+    return this._addLine(line)
+};
+
+/**
+ * AddCurvedLineSph
+ * @param {vec3} startPosition
+ * @param {quat4} startColor
+ * @param {vec3} endPosition
+ * @param {quat4} endColor
+ * @param {vec3} center
+ * @param {vec3} middle
+ * @param {Number} lineWidth
+ * @returns {Number} line index
+ */
+EveCurveLineSet.prototype.AddCurvedLineSph = function(startPosition, startColor, endPosition, endColor, center, middle, lineWidth)
+{
+    var phi1 = startPosition[0];
+    var theta1 = startPosition[1];
+    var radius1 = startPosition[2];
+    var phi2 = endPosition[0];
+    var theta2 = endPosition[1];
+    var radius2 = endPosition[2];
+    var phiM = middle[0];
+    var thetaM = middle[1];
+    var radiusM = middle[2];
+    // is given in spherical coords, so convert them into cartesian
+    var startPnt = [radius1 * Math.sin(phi1) * Math.sin(theta1), radius1 * Math.cos(theta1), radius1 * Math.cos(phi1) * Math.sin(theta1)];
+    var endPnt = [radius2 * Math.sin(phi2) * Math.sin(theta2), radius2 * Math.cos(theta2), radius2 * Math.cos(phi2) * Math.sin(theta2)];
+    var middlePnt = [radiusM * Math.sin(phiM) * Math.sin(thetaM), radiusM * Math.cos(thetaM), radiusM * Math.cos(phiM) * Math.sin(thetaM)];
+    // dont forget center!
+    vec3.add(startPnt, center);
+    vec3.add(endPnt, center);
+    vec3.add(middlePnt, center);
+    // add it
+    return this.AddCurvedLineCrt(startPnt, startColor, endPnt, endColor, middlePnt, lineWidth);
+};
+
+/**
+ * AddSpheredLineCrt
+ * @param {vec3} startPosition
+ * @param {quat4} startColor
+ * @param {vec3} endPosition
+ * @param {quat4} endColor
+ * @param {vec3} center
+ * @param {Number} lineWidth
+ * @returns {Number} line index
+ */
+EveCurveLineSet.prototype.AddSpheredLineCrt = function(startPosition, startColor, endPosition, endColor, center, lineWidth)
+{
+    var line = {
+        type: EveCurveLineSet.LINETYPE_SPHERED,
+        position1: startPosition,
+        color1: startColor,
+        position2: endPosition,
+        color2: endColor,
+        intermediatePosition: center,
+        width: lineWidth,
+        multiColor: [0, 0, 0, 0],
+        multiColorBorder: -1,
+        overlayColor: [0, 0, 0, 0],
+        animationSpeed: 0,
+        animationScale: 1,
+        numOfSegments: 20
     };
-    this.AddSpheredLineCrt = function(startPosition, startColor, endPosition, endColor, center, lineWidth)
+    return this._addLine(line)
+};
+
+/**
+ * AddSpheredLineSph
+ * @param {vec3} startPosition
+ * @param {quat4} startColor
+ * @param {vec3} endPosition
+ * @param {quat4} endColor
+ * @param {vec3} center
+ * @param {Number} lineWidth
+ * @returns {Number} line index
+ */
+EveCurveLineSet.prototype.AddSpheredLineSph = function(startPosition, startColor, endPosition, endColor, center, lineWidth)
+{
+    var phi1 = startPosition[0];
+    var theta1 = startPosition[1];
+    var radius1 = startPosition[2];
+    var phi2 = endPosition[0];
+    var theta2 = endPosition[1];
+    var radius2 = endPosition[2];
+    // is given in spherical coords, so convert them into cartesian
+    var startPnt = [radius1 * Math.sin(phi1) * Math.sin(theta1), radius1 * Math.cos(theta1), radius1 * Math.cos(phi1) * Math.sin(theta1)];
+    var endPnt = [radius2 * Math.sin(phi2) * Math.sin(theta2), radius2 * Math.cos(theta2), radius2 * Math.cos(phi2) * Math.sin(theta2)];
+    // dont forget center!
+    vec3.add(startPnt, center);
+    vec3.add(endPnt, center);
+    // add it
+    return this.AddSpheredLineCrt(startPnt, startColor, endPnt, endColor, lineWidth);
+};
+
+/**
+ * Changes a line's colors
+ * @param {Number} lineID
+ * @param {quat4} startColor
+ * @param {quat4} endColor
+ */
+EveCurveLineSet.prototype.ChangeLineColor = function(lineID, startColor, endColor)
+{
+    this.lines[lineID].color1 = startColor;
+    this.lines[lineID].color2 = endColor;
+};
+
+/**
+ * Changes a line's width
+ * @param {Number} lineID
+ * @param {Number} width
+ */
+EveCurveLineSet.prototype.ChangeLineWidth = function(lineID, width)
+{
+    this.lines[lineID].width = width;
+};
+
+/**
+ * Changes a lines start and end positions
+ * @param {Number} lineID
+ * @param {vec3} startPosition
+ * @param {vec3} endPosition
+ */
+EveCurveLineSet.prototype.ChangeLinePositionCrt = function(lineID, startPosition, endPosition)
+{
+    this.lines[lineID].position1 = startPosition;
+    this.lines[lineID].position2 = endPosition;
+};
+
+/**
+ * Changes a lines start, end and center positions
+ * @param {Number} lineID
+ * @param {vec3} startPosition
+ * @param {vec3} endPosition
+ * @param {vec3} center
+ */
+EveCurveLineSet.prototype.ChangeLinePositionSph = function(lineID, startPosition, endPosition, center)
+{
+    var phi1 = startPosition[0];
+    var theta1 = startPosition[1];
+    var radius1 = startPosition[2];
+    var phi2 = endPosition[0];
+    var theta2 = endPosition[1];
+    var radius2 = endPosition[2];
+    // is given in spherical coords, so convert them into cartesian
+    var startPnt = [radius1 * Math.sin(phi1) * Math.sin(theta1), radius1 * Math.cos(theta1), radius1 * Math.cos(phi1) * Math.sin(theta1)];
+    var endPnt = [radius2 * Math.sin(phi2) * Math.sin(theta2), radius2 * Math.cos(theta2), radius2 * Math.cos(phi2) * Math.sin(theta2)];
+    // dont forget center!
+    vec3.add(startPnt, center);
+    vec3.add(endPnt, center);
+    this.ChangeLinePositionCrt(lineID, startPnt, endPnt);
+};
+
+/**
+ * Changes a line's intermediate position
+ * @param {Number} lineID
+ * @param {vec3} intermediatePosition
+ */
+EveCurveLineSet.prototype.ChangeLineIntermediateCrt = function(lineID, intermediatePosition)
+{
+    this.lines[lineID].intermediatePosition = intermediatePosition;
+};
+
+/**
+ * Changes a line's intermediate and middle positions
+ * @param {Number} lineID
+ * @param {vec3} intermediatePosition
+ * @param {vec3} middle
+ */
+EveCurveLineSet.prototype.ChangeLineIntermediateSph = function(lineID, intermediatePosition, middle)
+{
+    var phiM = middle[0];
+    var thetaM = middle[1];
+    var radiusM = middle[2];
+    var middlePnt = [radiusM * Math.sin(phiM) * Math.sin(thetaM), radiusM * Math.cos(thetaM), radiusM * Math.cos(phiM) * Math.sin(thetaM)];
+    vec3.add(middlePnt, middle);
+    this.lines[lineID].intermediatePosition = intermediatePosition;
+};
+
+/**
+ * Changes line multi color parameters
+ * @param {Number} lineID
+ * @param {quat4} color
+ * @param {Number} border
+ */
+EveCurveLineSet.prototype.ChangeLineMultiColor = function(lineID, color, border)
+{
+    this.lines[lineID].multiColor = color;
+    this.lines[lineID].multiColorBorder = border;
+};
+
+/**
+ * Changes a line's animation parameters
+ * @param {Number} lineID
+ * @param {quat4} color
+ * @param {Number} speed
+ * @param {Number} scale
+ */
+EveCurveLineSet.prototype.ChangeLineAnimation = function(lineID, color, speed, scale)
+{
+    this.lines[lineID].overlayColor = color;
+    this.lines[lineID].animationSpeed = speed;
+    this.lines[lineID].animationScale = scale;
+};
+
+/**
+ * Changes a line's segmentation
+ * @param {Number} lineID
+ * @param {Number} numOfSegments
+ */
+EveCurveLineSet.prototype.ChangeLineSegmentation = function(lineID, numOfSegments)
+{
+    if (this.lines[lineID].type != EveCurveLineSet.LINETYPE_STRAIGHT)
     {
-        var line = {
-            type: LINETYPE_SPHERED,
-            position1: startPosition,
-            color1: startColor,
-            position2: endPosition,
-            color2: endColor,
-            intermediatePosition: center,
-            width: lineWidth,
-            multiColor: [0, 0, 0, 0],
-            multiColorBorder: -1,
-            overlayColor: [0, 0, 0, 0],
-            animationSpeed: 0,
-            animationScale: 1,
-            numOfSegments: 20
-        };
-        return addLine(line)
-    };
-    this.AddSpheredLineSph = function(startPosition, startColor, endPosition, endColor, center, lineWidth)
+        this.lines[lineID].numOfSegments = numOfSegments;
+    }
+};
+
+/**
+ * Removes a line
+ * @param {Number} lineID
+ */
+EveCurveLineSet.prototype.RemoveLine = function(lineID)
+{
+    this.emptyLineID.push(lineID);
+    this.lines[lineID].type = EveCurveLineSet.LINETYPE_INVALID;
+};
+
+/**
+ * Clears all lines
+ */
+EveCurveLineSet.prototype.ClearLines = function()
+{
+    this.lines = [];
+    this.emptyLineID = [];
+};
+
+/**
+ * Gets line count
+ * @returns {number}
+ * @private
+ */
+EveCurveLineSet.prototype._lineCount = function()
+{
+    var count = 0;
+    for (var i = 0; i < this.lines.length; ++i)
     {
-        var phi1 = startPosition.x;
-        var theta1 = startPosition.y;
-        var radius1 = startPosition.z;
-        var phi2 = endPosition.x;
-        var theta2 = endPosition.y;
-        var radius2 = endPosition.z;
-        // is given in spherical coords, so convert them into cartesian
-        var startPnt = [radius1 * Math.sin(phi1) * Math.sin(theta1), radius1 * Math.cos(theta1), radius1 * Math.cos(phi1) * Math.sin(theta1)];
-        var endPnt = [radius2 * Math.sin(phi2) * Math.sin(theta2), radius2 * Math.cos(theta2), radius2 * Math.cos(phi2) * Math.sin(theta2)];
-        // dont forget center!
-        vec3.add(startPnt, center);
-        vec3.add(endPnt, center);
-        // add it
-        return this.AddSpheredLineCrt(startPnt, startColor, endPnt, endColor, lineWidth);
-    };
-    this.ChangeLineColor = function(lineID, startColor, endColor)
-    {
-        lines[lineID].color1 = startColor;
-        lines[lineID].color2 = endColor;
-    };
-    this.ChangeLineWidth = function(lineID, width)
-    {
-        lines[lineID].width = width;
-    };
-    this.ChangeLinePositionCrt = function(lineID, startPosition, endPosition)
-    {
-        lines[lineID].position1 = startPosition;
-        lines[lineID].position2 = endPosition;
-    };
-    this.ChangeLinePositionSph = function(lineID, startPosition, endPosition, center)
-    {
-        var phi1 = startPosition.x;
-        var theta1 = startPosition.y;
-        var radius1 = startPosition.z;
-        var phi2 = endPosition.x;
-        var theta2 = endPosition.y;
-        var radius2 = endPosition.z;
-        // is given in spherical coords, so convert them into cartesian
-        var startPnt = [radius1 * Math.sin(phi1) * Math.sin(theta1), radius1 * Math.cos(theta1), radius1 * Math.cos(phi1) * Math.sin(theta1)];
-        var endPnt = [radius2 * Math.sin(phi2) * Math.sin(theta2), radius2 * Math.cos(theta2), radius2 * Math.cos(phi2) * Math.sin(theta2)];
-        // dont forget center!
-        vec3.add(startPnt, center);
-        vec3.add(endPnt, center);
-        this.ChangeLinePositionCrt(lineID, startPnt, endPnt);
-    };
-    this.ChangeLineIntermediateCrt = function(lineID, intermediatePosition)
-    {
-        lines[lineID].intermediatePosition = intermediatePosition;
-    };
-    this.ChangeLineIntermediateSph = function(lineID, intermediatePosition, center)
-    {
-        var phiM = middle.x;
-        var thetaM = middle.y;
-        var radiusM = middle.z;
-        var middlePnt = [radiusM * Math.sin(phiM) * Math.sin(thetaM), radiusM * Math.cos(thetaM), radiusM * Math.cos(phiM) * Math.sin(thetaM)];
-        vec3.add(middlePnt, center);
-        lines[lineID].intermediatePosition = intermediatePosition;
-    };
-    this.ChangeLineMultiColor = function(lineID, color, border)
-    {
-        lines[lineID].multiColor = color;
-        lines[lineID].multiColorBorder = border;
-    };
-    this.ChangeLineAnimation = function(lineID, color, speed, scale)
-    {
-        lines[lineID].overlayColor = color;
-        lines[lineID].animationSpeed = speed;
-        lines[lineID].animationScale = scale;
-    };
-    this.ChangeLineSegmentation = function(lineID, numOfSegments)
-    {
-        if (lines[lineID].type != LINETYPE_STRAIGHT)
+        if (this.lines[i].type != EveCurveLineSet.LINETYPE_INVALID)
         {
-            lines[lineID].numOfSegments = numOfSegments;
+            count += this.lines[i].numOfSegments;
         }
+    }
+    return count;
+}
 
-    };
-    this.RemoveLine = function(lineID)
+/**
+ * Fills color vertices
+ * @param lineData
+ * @param buffer
+ * @param offset
+ * @returns {*}
+ * @private
+ */
+EveCurveLineSet.prototype._fillColorVertices = function(lineData, buffer, offset)
+{
+    buffer[offset++] = lineData.multiColor[0];
+    buffer[offset++] = lineData.multiColor[1];
+    buffer[offset++] = lineData.multiColor[2];
+    buffer[offset++] = lineData.multiColor[3];
+    buffer[offset++] = lineData.overlayColor[0];
+    buffer[offset++] = lineData.overlayColor[1];
+    buffer[offset++] = lineData.overlayColor[2];
+    buffer[offset++] = lineData.overlayColor[3];
+    return offset;
+}
+
+/**
+ * Writes line vertices to the vertex buffer
+ * @param {EveCurveLineSet} self
+ * @param {vec3} position1
+ * @param {quat4} color1
+ * @param length1
+ * @param {vec3} position2
+ * @param {quat4} color2
+ * @param length2
+ * @param {Number} lineID
+ * @param buffer
+ * @param {number} offset
+ * @private
+ */
+EveCurveLineSet.prototype._writeLineVerticesToBuffer = function(self, position1, color1, length1, position2, color2, length2, lineID, buffer, offset)
+{
+    var lineData = this.lines[lineID];
+
+    buffer[offset++] = position1[0];
+    buffer[offset++] = position1[1];
+    buffer[offset++] = position1[2];
+    buffer[offset++] = position2[0] - position1[0];
+    buffer[offset++] = position2[1] - position1[1];
+    buffer[offset++] = position2[2] - position1[2];
+    buffer[offset++] = -self.lineWidthFactor * lineData.width;
+    buffer[offset++] = 0;
+    buffer[offset++] = length1;
+    buffer[offset++] = lineData.multiColorBorder;
+    buffer[offset++] = length2 - length1;
+    buffer[offset++] = lineData.animationSpeed;
+    buffer[offset++] = lineData.animationScale;
+    buffer[offset++] = lineID;
+    buffer[offset++] = color1[0];
+    buffer[offset++] = color1[1];
+    buffer[offset++] = color1[2];
+    buffer[offset++] = color1[3];
+    offset = this._fillColorVertices(lineData, buffer, offset);
+
+    buffer[offset++] = position1[0];
+    buffer[offset++] = position1[1];
+    buffer[offset++] = position1[2];
+    buffer[offset++] = position2[0] - position1[0];
+    buffer[offset++] = position2[1] - position1[1];
+    buffer[offset++] = position2[2] - position1[2];
+    buffer[offset++] = self.lineWidthFactor * lineData.width;
+    buffer[offset++] = 0;
+    buffer[offset++] = length1;
+    buffer[offset++] = lineData.multiColorBorder;
+    buffer[offset++] = length2 - length1;
+    buffer[offset++] = lineData.animationSpeed;
+    buffer[offset++] = lineData.animationScale;
+    buffer[offset++] = lineID;
+    buffer[offset++] = color1[0];
+    buffer[offset++] = color1[1];
+    buffer[offset++] = color1[2];
+    buffer[offset++] = color1[3];
+    offset = this._fillColorVertices(lineData, buffer, offset);
+
+    buffer[offset++] = position2[0];
+    buffer[offset++] = position2[1];
+    buffer[offset++] = position2[2];
+    buffer[offset++] = position1[0] - position2[0];
+    buffer[offset++] = position1[1] - position2[1];
+    buffer[offset++] = position1[2] - position2[2];
+    buffer[offset++] = -self.lineWidthFactor * lineData.width;
+    buffer[offset++] = 1;
+    buffer[offset++] = length2;
+    buffer[offset++] = lineData.multiColorBorder;
+    buffer[offset++] = length2 - length1;
+    buffer[offset++] = lineData.animationSpeed;
+    buffer[offset++] = lineData.animationScale;
+    buffer[offset++] = lineID;
+    buffer[offset++] = color2[0];
+    buffer[offset++] = color2[1];
+    buffer[offset++] = color2[2];
+    buffer[offset++] = color2[3];
+    offset = this._fillColorVertices(lineData, buffer, offset);
+
+    buffer[offset++] = position1[0];
+    buffer[offset++] = position1[1];
+    buffer[offset++] = position1[2];
+    buffer[offset++] = position2[0] - position1[0];
+    buffer[offset++] = position2[1] - position1[1];
+    buffer[offset++] = position2[2] - position1[2];
+    buffer[offset++] = self.lineWidthFactor * lineData.width;
+    buffer[offset++] = 0;
+    buffer[offset++] = length1;
+    buffer[offset++] = lineData.multiColorBorder;
+    buffer[offset++] = length2 - length1;
+    buffer[offset++] = lineData.animationSpeed;
+    buffer[offset++] = lineData.animationScale;
+    buffer[offset++] = lineID;
+    buffer[offset++] = color1[0];
+    buffer[offset++] = color1[1];
+    buffer[offset++] = color1[2];
+    buffer[offset++] = color1[3];
+    offset = this._fillColorVertices(lineData, buffer, offset);
+
+    buffer[offset++] = position2[0];
+    buffer[offset++] = position2[1];
+    buffer[offset++] = position2[2];
+    buffer[offset++] = position1[0] - position2[0];
+    buffer[offset++] = position1[1] - position2[1];
+    buffer[offset++] = position1[2] - position2[2];
+    buffer[offset++] = self.lineWidthFactor * lineData.width;
+    buffer[offset++] = 1;
+    buffer[offset++] = length2;
+    buffer[offset++] = lineData.multiColorBorder;
+    buffer[offset++] = length2 - length1;
+    buffer[offset++] = lineData.animationSpeed;
+    buffer[offset++] = lineData.animationScale;
+    buffer[offset++] = lineID;
+    buffer[offset++] = color2[0];
+    buffer[offset++] = color2[1];
+    buffer[offset++] = color2[2];
+    buffer[offset++] = color2[3];
+    offset = this._fillColorVertices(lineData, buffer, offset);
+
+    buffer[offset++] = position2[0];
+    buffer[offset++] = position2[1];
+    buffer[offset++] = position2[2];
+    buffer[offset++] = position1[0] - position2[0];
+    buffer[offset++] = position1[1] - position2[1];
+    buffer[offset++] = position1[2] - position2[2];
+    buffer[offset++] = -self.lineWidthFactor * lineData.width;
+    buffer[offset++] = 1;
+    buffer[offset++] = length2;
+    buffer[offset++] = lineData.multiColorBorder;
+    buffer[offset++] = length2 - length1;
+    buffer[offset++] = lineData.animationSpeed;
+    buffer[offset++] = lineData.animationScale;
+    buffer[offset++] = lineID;
+    buffer[offset++] = color2[0];
+    buffer[offset++] = color2[1];
+    buffer[offset++] = color2[2];
+    buffer[offset++] = color2[3];
+    offset = this._fillColorVertices(lineData, buffer, offset);
+}
+
+/**
+ * Updates line changes
+ */
+EveCurveLineSet.prototype.SubmitChanges = function()
+{
+    this._vertexBuffer = null;
+    if (!this.lines.length)
     {
-        emptyLineID.push(lineID);
-        lines[lineID].type = LINETYPE_INVALID;
-    };
-    this.ClearLines = function()
-    {
-        lines = [];
-        emptyLineID = [];
-    };
-
-    var vertexSize = 26;
-    var vb = null;
-    var vbSize = 0;
-    var declaration = new Tw2VertexDeclaration();
-    declaration.elements.push(new Tw2VertexElement(Tw2VertexDeclaration.DECL_POSITION, 0, device.gl.FLOAT, 3, 0));
-    declaration.elements.push(new Tw2VertexElement(Tw2VertexDeclaration.DECL_TEXCOORD, 0, device.gl.FLOAT, 4, 12));
-    declaration.elements.push(new Tw2VertexElement(Tw2VertexDeclaration.DECL_TEXCOORD, 1, device.gl.FLOAT, 4, 28));
-    declaration.elements.push(new Tw2VertexElement(Tw2VertexDeclaration.DECL_TEXCOORD, 2, device.gl.FLOAT, 3, 44));
-
-    declaration.elements.push(new Tw2VertexElement(Tw2VertexDeclaration.DECL_COLOR, 0, device.gl.FLOAT, 4, 56));
-    declaration.elements.push(new Tw2VertexElement(Tw2VertexDeclaration.DECL_COLOR, 1, device.gl.FLOAT, 4, 72));
-    declaration.elements.push(new Tw2VertexElement(Tw2VertexDeclaration.DECL_COLOR, 2, device.gl.FLOAT, 4, 88));
-    declaration.stride = 4 * vertexSize;
-    declaration.RebuildHash();
-
-    function lineCount()
-    {
-        var count = 0;
-        for (var i = 0; i < lines.length; ++i)
-        {
-            if (lines[i].type != LINETYPE_INVALID)
-            {
-                count += lines[i].numOfSegments;
-            }
-        }
-        return count;
+        return;
     }
 
-    function fillColorVertices(lineData, buffer, offset)
+    this._vertexBufferSize = this._lineCount();
+    var data = new Float32Array(this._vertexBufferSize * 6 * this._vertexSize);
+    var offset = 0;
+
+    var startDir = vec3.create();
+    var endDir = vec3.create();
+    var startDirNrm = vec3.create();
+    var endDirNrm = vec3.create();
+    var rotationAxis = vec3.create();
+    var rotationMatrix = mat4.create();
+    var dir1 = vec3.create();
+    var dir2 = vec3.create();
+    var col1 = quat4.create();
+    var col2 = quat4.create();
+    var pt1 = vec3.create();
+    var pt2 = vec3.create();
+    var j, tmp, segmentFactor;
+
+    for (var i = 0; i < this.lines.length; ++i)
     {
-        buffer[offset++] = lineData.multiColor[0];
-        buffer[offset++] = lineData.multiColor[1];
-        buffer[offset++] = lineData.multiColor[2];
-        buffer[offset++] = lineData.multiColor[3];
-        buffer[offset++] = lineData.overlayColor[0];
-        buffer[offset++] = lineData.overlayColor[1];
-        buffer[offset++] = lineData.overlayColor[2];
-        buffer[offset++] = lineData.overlayColor[3];
-        return offset;
+        switch (this.lines[i].type)
+        {
+            case EveCurveLineSet.LINETYPE_INVALID:
+                break;
+
+            case EveCurveLineSet.LINETYPE_STRAIGHT:
+                this._writeLineVerticesToBuffer(this, this.lines[i].position1, this.lines[i].color1, 0, this.lines[i].position2, this.lines[i].color2, 1, i, data, offset);
+                offset += 6 * this._vertexSize;
+                break;
+
+            case EveCurveLineSet.LINETYPE_SPHERED:
+                vec3.subtract(this.lines[i].position1, this.lines[i].intermediatePosition, startDir);
+                vec3.subtract(this.lines[i].position2, this.lines[i].intermediatePosition, endDir);
+                vec3.normalize(startDir, startDirNrm);
+                vec3.normalize(endDir, endDirNrm);
+
+                vec3.cross(startDir, endDir, rotationAxis);
+                var fullAngle = Math.acos(vec3.dot(startDirNrm, endDirNrm));
+                var segmentAngle = fullAngle / this.lines[i].numOfSegments;
+                mat4.rotate(mat4.identity(rotationMatrix), segmentAngle, rotationAxis);
+
+                vec3.set(startDir, dir1);
+                quat4.set(this.lines[i].color1, col1);
+
+                for (j = 0; j < this.lines[i].numOfSegments; ++j)
+                {
+                    segmentFactor = (j + 1) / this.lines[i].numOfSegments;
+                    mat4.multiplyVec3(rotationMatrix, dir1, dir2);
+                    col2[0] = this.lines[i].color1[0] * (1 - segmentFactor) + this.lines[i].color2[0] * segmentFactor;
+                    col2[1] = this.lines[i].color1[1] * (1 - segmentFactor) + this.lines[i].color2[1] * segmentFactor;
+                    col2[2] = this.lines[i].color1[2] * (1 - segmentFactor) + this.lines[i].color2[2] * segmentFactor;
+                    col2[3] = this.lines[i].color1[3] * (1 - segmentFactor) + this.lines[i].color2[3] * segmentFactor;
+                    vec3.add(dir1, this.lines[i].intermediatePosition, pt1);
+                    vec3.add(dir2, this.lines[i].intermediatePosition, pt2);
+
+                    this._writeLineVerticesToBuffer(this, pt1, col1, j / this.lines[i].numOfSegments, pt2, col2, segmentFactor, i, data, offset);
+                    offset += 6 * this._vertexSize;
+
+                    tmp = dir1;
+                    dir1 = dir2;
+                    dir2 = tmp;
+                    tmp = col1;
+                    col1 = col2;
+                    col2 = tmp;
+                }
+                break;
+
+            case EveCurveLineSet.LINETYPE_CURVED:
+                var tangent1 = vec3.create();
+                var tangent2 = vec3.create();
+                var pos1 = vec3.create();
+                var pos2 = vec3.create();
+
+                vec3.subtract(this.lines[i].intermediatePosition, this.lines[i].position1, tangent1);
+                vec3.subtract(this.lines[i].position2, this.lines[i].intermediatePosition, tangent2);
+
+                vec3.set(this.lines[i].position1, pos1);
+                vec3.set(this.lines[i].color1, col1);
+                for (j = 0; j < this.lines[i].numOfSegments; ++j)
+                {
+                    segmentFactor = (j + 1) / this.lines[i].numOfSegments;
+                    vec3Hermite(pos2, this.lines[i].position1, tangent1, this.lines[i].position2, tangent2, segmentFactor);
+                    col2[0] = this.lines[i].color1[0] * (1 - segmentFactor) + this.lines[i].color2[0] * segmentFactor;
+                    col2[1] = this.lines[i].color1[1] * (1 - segmentFactor) + this.lines[i].color2[1] * segmentFactor;
+                    col2[2] = this.lines[i].color1[2] * (1 - segmentFactor) + this.lines[i].color2[2] * segmentFactor;
+                    col2[3] = this.lines[i].color1[3] * (1 - segmentFactor) + this.lines[i].color2[3] * segmentFactor;
+                    this._writeLineVerticesToBuffer(this, pos1, col1, j / this.lines[i].numOfSegments, pos2, col2, segmentFactor, i, data, offset);
+                    offset += 6 * this._vertexSize;
+
+                    tmp = pos1;
+                    pos1 = pos2;
+                    pos2 = tmp;
+                    tmp = col1;
+                    col1 = col2;
+                    col2 = tmp;
+                }
+        }
     }
 
-    function writeLineVerticesToBuffer(self, position1, color1, length1, position2, color2, length2, lineID, buffer, offset)
+    if (this._vertexBuffer)
     {
-        var lineData = lines[lineID];
-
-        buffer[offset++] = position1[0];
-        buffer[offset++] = position1[1];
-        buffer[offset++] = position1[2];
-        buffer[offset++] = position2[0] - position1[0];
-        buffer[offset++] = position2[1] - position1[1];
-        buffer[offset++] = position2[2] - position1[2];
-        buffer[offset++] = -self.lineWidthFactor * lineData.width;
-        buffer[offset++] = 0;
-        buffer[offset++] = length1;
-        buffer[offset++] = lineData.multiColorBorder;
-        buffer[offset++] = length2 - length1;
-        buffer[offset++] = lineData.animationSpeed;
-        buffer[offset++] = lineData.animationScale;
-        buffer[offset++] = lineID;
-        buffer[offset++] = color1[0];
-        buffer[offset++] = color1[1];
-        buffer[offset++] = color1[2];
-        buffer[offset++] = color1[3];
-        offset = fillColorVertices(lineData, buffer, offset);
-
-        buffer[offset++] = position1[0];
-        buffer[offset++] = position1[1];
-        buffer[offset++] = position1[2];
-        buffer[offset++] = position2[0] - position1[0];
-        buffer[offset++] = position2[1] - position1[1];
-        buffer[offset++] = position2[2] - position1[2];
-        buffer[offset++] = self.lineWidthFactor * lineData.width;
-        buffer[offset++] = 0;
-        buffer[offset++] = length1;
-        buffer[offset++] = lineData.multiColorBorder;
-        buffer[offset++] = length2 - length1;
-        buffer[offset++] = lineData.animationSpeed;
-        buffer[offset++] = lineData.animationScale;
-        buffer[offset++] = lineID;
-        buffer[offset++] = color1[0];
-        buffer[offset++] = color1[1];
-        buffer[offset++] = color1[2];
-        buffer[offset++] = color1[3];
-        offset = fillColorVertices(lineData, buffer, offset);
-
-        buffer[offset++] = position2[0];
-        buffer[offset++] = position2[1];
-        buffer[offset++] = position2[2];
-        buffer[offset++] = position1[0] - position2[0];
-        buffer[offset++] = position1[1] - position2[1];
-        buffer[offset++] = position1[2] - position2[2];
-        buffer[offset++] = -self.lineWidthFactor * lineData.width;
-        buffer[offset++] = 1;
-        buffer[offset++] = length2;
-        buffer[offset++] = lineData.multiColorBorder;
-        buffer[offset++] = length2 - length1;
-        buffer[offset++] = lineData.animationSpeed;
-        buffer[offset++] = lineData.animationScale;
-        buffer[offset++] = lineID;
-        buffer[offset++] = color2[0];
-        buffer[offset++] = color2[1];
-        buffer[offset++] = color2[2];
-        buffer[offset++] = color2[3];
-        offset = fillColorVertices(lineData, buffer, offset);
-
-
-        buffer[offset++] = position1[0];
-        buffer[offset++] = position1[1];
-        buffer[offset++] = position1[2];
-        buffer[offset++] = position2[0] - position1[0];
-        buffer[offset++] = position2[1] - position1[1];
-        buffer[offset++] = position2[2] - position1[2];
-        buffer[offset++] = self.lineWidthFactor * lineData.width;
-        buffer[offset++] = 0;
-        buffer[offset++] = length1;
-        buffer[offset++] = lineData.multiColorBorder;
-        buffer[offset++] = length2 - length1;
-        buffer[offset++] = lineData.animationSpeed;
-        buffer[offset++] = lineData.animationScale;
-        buffer[offset++] = lineID;
-        buffer[offset++] = color1[0];
-        buffer[offset++] = color1[1];
-        buffer[offset++] = color1[2];
-        buffer[offset++] = color1[3];
-        offset = fillColorVertices(lineData, buffer, offset);
-
-        buffer[offset++] = position2[0];
-        buffer[offset++] = position2[1];
-        buffer[offset++] = position2[2];
-        buffer[offset++] = position1[0] - position2[0];
-        buffer[offset++] = position1[1] - position2[1];
-        buffer[offset++] = position1[2] - position2[2];
-        buffer[offset++] = self.lineWidthFactor * lineData.width;
-        buffer[offset++] = 1;
-        buffer[offset++] = length2;
-        buffer[offset++] = lineData.multiColorBorder;
-        buffer[offset++] = length2 - length1;
-        buffer[offset++] = lineData.animationSpeed;
-        buffer[offset++] = lineData.animationScale;
-        buffer[offset++] = lineID;
-        buffer[offset++] = color2[0];
-        buffer[offset++] = color2[1];
-        buffer[offset++] = color2[2];
-        buffer[offset++] = color2[3];
-        offset = fillColorVertices(lineData, buffer, offset);
-
-        buffer[offset++] = position2[0];
-        buffer[offset++] = position2[1];
-        buffer[offset++] = position2[2];
-        buffer[offset++] = position1[0] - position2[0];
-        buffer[offset++] = position1[1] - position2[1];
-        buffer[offset++] = position1[2] - position2[2];
-        buffer[offset++] = -self.lineWidthFactor * lineData.width;
-        buffer[offset++] = 1;
-        buffer[offset++] = length2;
-        buffer[offset++] = lineData.multiColorBorder;
-        buffer[offset++] = length2 - length1;
-        buffer[offset++] = lineData.animationSpeed;
-        buffer[offset++] = lineData.animationScale;
-        buffer[offset++] = lineID;
-        buffer[offset++] = color2[0];
-        buffer[offset++] = color2[1];
-        buffer[offset++] = color2[2];
-        buffer[offset++] = color2[3];
-        offset = fillColorVertices(lineData, buffer, offset);
-
+        device.gl.deleteBuffer(this._vertexBuffer);
     }
 
-    function vec3Hermite(out, v1, t1, v2, t2, s)
-    {
-        var k3 = 2 * s * s * s - 3 * s * s + 1;
-        var k2 = -2 * s * s * s + 3 * s * s;
-        var k1 = s * s * s - 2 * s * s + s;
-        var k0 = s * s * s - s * s;
+    this._vertexBuffer = device.gl.createBuffer();
+    device.gl.bindBuffer(device.gl.ARRAY_BUFFER, this._vertexBuffer);
+    device.gl.bufferData(device.gl.ARRAY_BUFFER, data, device.gl.STATIC_DRAW);
+    device.gl.bindBuffer(device.gl.ARRAY_BUFFER, null);
+};
 
-        out[0] = k3 * v1[0] + k2 * v2[0] + k1 * t1[0] + k0 * t2[0];
-        out[1] = k3 * v1[1] + k2 * v2[1] + k1 * t1[1] + k0 * t2[1];
-        out[2] = k3 * v1[2] + k2 * v2[2] + k1 * t1[2] + k0 * t2[2];
-        return out;
+EveCurveLineSet.LINETYPE_INVALID = 0;
+EveCurveLineSet.LINETYPE_STRAIGHT = 1;
+EveCurveLineSet.LINETYPE_SPHERED = 2;
+EveCurveLineSet.LINETYPE_CURVED = 3;
+
+/**
+ * Accumulates render batches
+ * @param {RenderMode} mode
+ * @param {Tw2BatchAccumulator} accumulator
+ */
+EveCurveLineSet.prototype.GetBatches = function(mode, accumulator)
+{
+    if (!this.display || !this._vertexBuffer)
+    {
+        return;
     }
 
-    this.SubmitChanges = function()
+    if (mode == device.RM_TRANSPARENT && !this.additive || mode == device.RM_ADDITIVE && this.additive)
     {
-        vb = null;
-        if (!lines.length)
-        {
-            return;
-        }
-        vbSize = lineCount();
-        var data = new Float32Array(vbSize * 6 * vertexSize);
-        var offset = 0;
+        var batch = new Tw2ForwardingRenderBatch();
+        mat4.transpose(this.transform, this.perObjectData.perObjectVSData.Get('WorldMat'));
+        mat4.transpose(this.transform, this.perObjectData.perObjectPSData.Get('WorldMat'));
+        batch.perObjectData = this.perObjectData;
+        batch.geometryProvider = this;
+        batch.renderMode = mode;
+        accumulator.Commit(batch);
+    }
+};
 
-        var startDir = vec3.create();
-        var endDir = vec3.create();
-        var startDirNrm = vec3.create();
-        var endDirNrm = vec3.create();
-        var rotationAxis = vec3.create();
-        var rotationMatrix = mat4.create();
-        var dir1 = vec3.create();
-        var dir2 = vec3.create();
-        var col1 = quat4.create();
-        var col2 = quat4.create();
-        var pt1 = vec3.create();
-        var pt2 = vec3.create();
-        var j, tmp, segmentFactor;
-
-        for (var i = 0; i < lines.length; ++i)
-        {
-            switch (lines[i].type)
-            {
-                case LINETYPE_INVALID:
-                    break;
-                case LINETYPE_STRAIGHT:
-                    writeLineVerticesToBuffer(this, lines[i].position1, lines[i].color1, 0, lines[i].position2, lines[i].color2, 1, i, data, offset);
-                    offset += 6 * vertexSize;
-                    break;
-                case LINETYPE_SPHERED:
-                    vec3.subtract(lines[i].position1, lines[i].intermediatePosition, startDir);
-                    vec3.subtract(lines[i].position2, lines[i].intermediatePosition, endDir);
-                    vec3.normalize(startDir, startDirNrm);
-                    vec3.normalize(endDir, endDirNrm);
-
-                    vec3.cross(startDir, endDir, rotationAxis);
-                    var fullAngle = Math.acos(vec3.dot(startDirNrm, endDirNrm));
-                    var segmentAngle = fullAngle / lines[i].numOfSegments;
-                    mat4.rotate(mat4.identity(rotationMatrix), segmentAngle, rotationAxis);
-
-                    vec3.set(startDir, dir1);
-                    quat4.set(lines[i].color1, col1);
-
-                    for (j = 0; j < lines[i].numOfSegments; ++j)
-                    {
-                        segmentFactor = (j + 1) / lines[i].numOfSegments;
-                        mat4.multiplyVec3(rotationMatrix, dir1, dir2);
-                        col2[0] = lines[i].color1[0] * (1 - segmentFactor) + lines[i].color2[0] * segmentFactor;
-                        col2[1] = lines[i].color1[1] * (1 - segmentFactor) + lines[i].color2[1] * segmentFactor;
-                        col2[2] = lines[i].color1[2] * (1 - segmentFactor) + lines[i].color2[2] * segmentFactor;
-                        col2[3] = lines[i].color1[3] * (1 - segmentFactor) + lines[i].color2[3] * segmentFactor;
-                        vec3.add(dir1, lines[i].intermediatePosition, pt1);
-                        vec3.add(dir2, lines[i].intermediatePosition, pt2);
-
-                        writeLineVerticesToBuffer(this, pt1, col1, j / lines[i].numOfSegments, pt2, col2, segmentFactor, i, data, offset);
-                        offset += 6 * vertexSize;
-
-                        tmp = dir1;
-                        dir1 = dir2;
-                        dir2 = tmp;
-                        tmp = col1;
-                        col1 = col2;
-                        col2 = tmp;
-                    }
-                    break;
-                case LINETYPE_CURVED:
-                    var tangent1 = vec3.create();
-                    var tangent2 = vec3.create();
-                    var pos1 = vec3.create();
-                    var pos2 = vec3.create();
-
-                    vec3.subtract(lines[i].intermediatePosition, lines[i].position1, tangent1);
-                    vec3.subtract(lines[i].position2, lines[i].intermediatePosition, tangent2);
-
-                    vec3.set(lines[i].position1, pos1);
-                    vec3.set(lines[i].color1, col1);
-                    for (j = 0; j < lines[i].numOfSegments; ++j)
-                    {
-                        segmentFactor = (j + 1) / lines[i].numOfSegments;
-                        vec3Hermite(pos2, lines[i].position1, tangent1, lines[i].position2, tangent2, segmentFactor);
-                        col2[0] = lines[i].color1[0] * (1 - segmentFactor) + lines[i].color2[0] * segmentFactor;
-                        col2[1] = lines[i].color1[1] * (1 - segmentFactor) + lines[i].color2[1] * segmentFactor;
-                        col2[2] = lines[i].color1[2] * (1 - segmentFactor) + lines[i].color2[2] * segmentFactor;
-                        col2[3] = lines[i].color1[3] * (1 - segmentFactor) + lines[i].color2[3] * segmentFactor;
-                        writeLineVerticesToBuffer(this, pos1, col1, j / lines[i].numOfSegments, pos2, col2, segmentFactor, i, data, offset);
-                        offset += 6 * vertexSize;
-
-                        tmp = pos1;
-                        pos1 = pos2;
-                        pos2 = tmp;
-                        tmp = col1;
-                        col1 = col2;
-                        col2 = tmp;
-                    }
-            }
-        }
-
-        if (vb)
-        {
-            device.gl.deleteBuffer(vb);
-        }
-        vb = device.gl.createBuffer();
-        device.gl.bindBuffer(device.gl.ARRAY_BUFFER, vb);
-        device.gl.bufferData(device.gl.ARRAY_BUFFER, data, device.gl.STATIC_DRAW);
-        device.gl.bindBuffer(device.gl.ARRAY_BUFFER, null);
-    };
-    this.GetBatches = function(mode, accumulator)
+/**
+ * Unloads the curve line set vertex buffer
+ */
+EveCurveLineSet.prototype.Unload = function()
+{
+    if (this._vertexBuffer)
     {
-        if (!this.display || !vb)
-        {
-            return;
-        }
-        if (mode == device.RM_TRANSPARENT && !this.additive || mode == device.RM_ADDITIVE && this.additive)
-        {
-            var batch = new Tw2ForwardingRenderBatch();
-            mat4.transpose(transform, perObjectData.perObjectVSData.Get('WorldMat'));
-            mat4.transpose(transform, perObjectData.perObjectPSData.Get('WorldMat'));
-            batch.perObjectData = perObjectData;
-            batch.geometryProvider = this;
-            batch.renderMode = mode;
-            accumulator.Commit(batch);
-        }
-    };
-    this.Unload = function()
+        device.gl.deleteBuffer(this._vertexBuffer);
+        this._vertexBuffer = null;
+    }
+};
+
+/**
+ * Renders lines
+ * @param {RenderBatch} batch
+ * @param {Tw2Effect} [overrideEffect]
+ * @returns {boolean}
+ */
+EveCurveLineSet.prototype.Render = function(batch, overrideEffect)
+{
+    var effect = overrideEffect || this.lineEffect;
+    var effectRes = effect.GetEffectRes();
+    if (!effectRes._isGood)
     {
-        if (vb)
-        {
-            device.gl.deleteBuffer(vb);
-            vb = null;
-        }
-    };
-    /**
-     * @return {boolean}
-     */
-    this.Render = function(batch, overrideEffect)
+        return false;
+    }
+
+    var d = device;
+    d.gl.bindBuffer(d.gl.ARRAY_BUFFER, this._vertexBuffer);
+
+    if (this.disableDepth) device.gl.disable(device.gl.DEPTH_TEST);
+
+    var passCount = effect.GetPassCount();
+    for (var pass = 0; pass < passCount; ++pass)
     {
-        var effect = overrideEffect || this.lineEffect;
-        var effectRes = effect.GetEffectRes();
-        if (!effectRes._isGood)
+        effect.ApplyPass(pass);
+        var passInput = effect.GetPassInput(pass);
+        if (!this.declaration.SetDeclaration(passInput, this.declaration.stride))
         {
             return false;
         }
-        var d = device;
-        d.gl.bindBuffer(d.gl.ARRAY_BUFFER, vb);
+        d.ApplyShadowState();
+        d.gl.drawArrays(d.gl.TRIANGLES, 0, this._vertexBufferSize * 6);
+    }
 
-        var passCount = effect.GetPassCount();
-        for (var pass = 0; pass < passCount; ++pass)
-        {
-            effect.ApplyPass(pass);
-            var passInput = effect.GetPassInput(pass);
-            if (!declaration.SetDeclaration(passInput, declaration.stride))
-            {
-                return false;
-            }
-            d.ApplyShadowState();
-            d.gl.drawArrays(d.gl.TRIANGLES, 0, vbSize * 6);
-        }
-        return true;
-    };
+    if (this.disableDepth) device.gl.enable(device.gl.DEPTH_TEST);
+    return true;
+};
 
-    this.Update = function() {};
-    this.UpdateViewDependentData = function(parentTransform)
-    {
-        mat4.identity(transform);
-        mat4.translate(transform, this.translation);
-        var rotationTransform = mat4.transpose(quat4.toMat4(this.rotation, mat4.create()));
-        mat4.multiply(transform, rotationTransform, transform);
-        mat4.scale(transform, this.scaling);
-        mat4.multiply(transform, parentTransform);
-    };
-}
+/**
+ * Per frame update
+ */
+EveCurveLineSet.prototype.Update = function() {};
+
+/**
+ * Per frame view dependent data update
+ * @param {mat4} parentTransform
+ */
+EveCurveLineSet.prototype.UpdateViewDependentData = function(parentTransform)
+{
+    mat4.identity(this.transform);
+    mat4.translate(this.transform, this.translation);
+    var rotationTransform = mat4.transpose(quat4.toMat4(this.rotation, mat4.create()));
+    mat4.multiply(this.transform, rotationTransform, this.transform);
+    mat4.scale(this.transform, this.scaling);
+    mat4.multiply(this.transform, parentTransform);
+};
 
 /**
  * Gets curve line set res objects

--- a/src/eve/EveCurveLineSet.js
+++ b/src/eve/EveCurveLineSet.js
@@ -91,7 +91,7 @@ function EveCurveLineSet()
 /**
  * Initializes the Curve line set
  */
-this.Initialize = function()
+EveCurveLineSet.prototype.Initialize = function()
 {
     mat4.identity(this.transform);
     mat4.translate(this.transform, this.translation);

--- a/src/eve/EveCurveLineSet.js
+++ b/src/eve/EveCurveLineSet.js
@@ -1,4 +1,5 @@
-function EveCurveLineSet() {
+function EveCurveLineSet()
+{
     this.lineEffect = new Tw2Effect();
     this.lineEffect.effectFilePath = "res:/Graphics/Effect/Managed/Space/SpecialFX/Lines3D.fx";
     this.lineEffect.Initialize();
@@ -12,20 +13,21 @@ function EveCurveLineSet() {
     this.display = true;
     this.depthOffset = 0;
 
-	var perObjectData = new Tw2PerObjectData();
-	perObjectData.perObjectVSData = new Tw2RawData();
-	perObjectData.perObjectVSData.Declare('WorldMat', 16);
-	perObjectData.perObjectVSData.Create();
+    var perObjectData = new Tw2PerObjectData();
+    perObjectData.perObjectVSData = new Tw2RawData();
+    perObjectData.perObjectVSData.Declare('WorldMat', 16);
+    perObjectData.perObjectVSData.Create();
 
-	perObjectData.perObjectPSData = new Tw2RawData();
-	perObjectData.perObjectPSData.Declare('WorldMat', 16);
-	perObjectData.perObjectPSData.Create();
+    perObjectData.perObjectPSData = new Tw2RawData();
+    perObjectData.perObjectPSData.Declare('WorldMat', 16);
+    perObjectData.perObjectPSData.Create();
 
     var transform = mat4.identity(mat4.create());
     var lines = [];
     var emptyLineID = [];
 
-    this.Initialize = function () {
+    this.Initialize = function()
+    {
         mat4.identity(transform);
         mat4.translate(transform, this.translation);
         var rotationTransform = mat4.transpose(quat4.toMat4(this.rotation, mat4.create()));
@@ -38,8 +40,10 @@ function EveCurveLineSet() {
     var LINETYPE_SPHERED = 2;
     var LINETYPE_CURVED = 3;
 
-    function addLine(line) {
-        if (emptyLineID.length) {
+    function addLine(line)
+    {
+        if (emptyLineID.length)
+        {
             var index = emptyLineID.pop();
             lines[index] = line;
             return index;
@@ -47,7 +51,8 @@ function EveCurveLineSet() {
         lines.push(line);
         return lines.length - 1;
     }
-    this.AddStraightLine = function (startPosition, startColor, endPosition, endColor, lineWidth) {
+    this.AddStraightLine = function(startPosition, startColor, endPosition, endColor, lineWidth)
+    {
         var line = {
             type: LINETYPE_STRAIGHT,
             position1: startPosition,
@@ -65,7 +70,8 @@ function EveCurveLineSet() {
         };
         return addLine(line)
     };
-    this.AddCurvedLineCrt = function (startPosition, startColor, endPosition, endColor, middle, lineWidth) {
+    this.AddCurvedLineCrt = function(startPosition, startColor, endPosition, endColor, middle, lineWidth)
+    {
         var line = {
             type: LINETYPE_CURVED,
             position1: startPosition,
@@ -83,7 +89,8 @@ function EveCurveLineSet() {
         };
         return addLine(line)
     };
-    this.AddCurvedLineSph = function (startPosition, startColor, endPosition, endColor, center, middle, lineWidth) {
+    this.AddCurvedLineSph = function(startPosition, startColor, endPosition, endColor, center, middle, lineWidth)
+    {
         var phi1 = startPosition.x;
         var theta1 = startPosition.y;
         var radius1 = startPosition.z;
@@ -94,17 +101,18 @@ function EveCurveLineSet() {
         var thetaM = middle.y;
         var radiusM = middle.z;
         // is given in spherical coords, so convert them into cartesian
-        var startPnt = [ radius1 * Math.sin( phi1 ) * Math.sin( theta1 ), radius1 * Math.cos( theta1 ), radius1 * Math.cos( phi1 ) * Math.sin( theta1 ) ];
-        var endPnt = [ radius2 * Math.sin( phi2 ) * Math.sin( theta2 ), radius2 * Math.cos( theta2 ), radius2 * Math.cos( phi2 ) * Math.sin( theta2 ) ];
-        var middlePnt = [ radiusM * Math.sin( phiM ) * Math.sin( thetaM ), radiusM * Math.cos( thetaM ), radiusM * Math.cos( phiM ) * Math.sin( thetaM ) ];
+        var startPnt = [radius1 * Math.sin(phi1) * Math.sin(theta1), radius1 * Math.cos(theta1), radius1 * Math.cos(phi1) * Math.sin(theta1)];
+        var endPnt = [radius2 * Math.sin(phi2) * Math.sin(theta2), radius2 * Math.cos(theta2), radius2 * Math.cos(phi2) * Math.sin(theta2)];
+        var middlePnt = [radiusM * Math.sin(phiM) * Math.sin(thetaM), radiusM * Math.cos(thetaM), radiusM * Math.cos(phiM) * Math.sin(thetaM)];
         // dont forget center!
         vec3.add(startPnt, center);
         vec3.add(endPnt, center);
         vec3.add(middlePnt, center);
         // add it
-        return this.AddCurvedLineCrt( startPnt, startColor, endPnt, endColor, middlePnt, lineWidth );
+        return this.AddCurvedLineCrt(startPnt, startColor, endPnt, endColor, middlePnt, lineWidth);
     };
-    this.AddSpheredLineCrt = function (startPosition, startColor, endPosition, endColor, center, lineWidth) {
+    this.AddSpheredLineCrt = function(startPosition, startColor, endPosition, endColor, center, lineWidth)
+    {
         var line = {
             type: LINETYPE_SPHERED,
             position1: startPosition,
@@ -122,7 +130,8 @@ function EveCurveLineSet() {
         };
         return addLine(line)
     };
-    this.AddSpheredLineSph = function (startPosition, startColor, endPosition, endColor, center, lineWidth) {
+    this.AddSpheredLineSph = function(startPosition, startColor, endPosition, endColor, center, lineWidth)
+    {
         var phi1 = startPosition.x;
         var theta1 = startPosition.y;
         var radius1 = startPosition.z;
@@ -130,26 +139,30 @@ function EveCurveLineSet() {
         var theta2 = endPosition.y;
         var radius2 = endPosition.z;
         // is given in spherical coords, so convert them into cartesian
-        var startPnt = [ radius1 * Math.sin( phi1 ) * Math.sin( theta1 ), radius1 * Math.cos( theta1 ), radius1 * Math.cos( phi1 ) * Math.sin( theta1 ) ];
-        var endPnt = [ radius2 * Math.sin( phi2 ) * Math.sin( theta2 ), radius2 * Math.cos( theta2 ), radius2 * Math.cos( phi2 ) * Math.sin( theta2 ) ];
+        var startPnt = [radius1 * Math.sin(phi1) * Math.sin(theta1), radius1 * Math.cos(theta1), radius1 * Math.cos(phi1) * Math.sin(theta1)];
+        var endPnt = [radius2 * Math.sin(phi2) * Math.sin(theta2), radius2 * Math.cos(theta2), radius2 * Math.cos(phi2) * Math.sin(theta2)];
         // dont forget center!
         vec3.add(startPnt, center);
         vec3.add(endPnt, center);
         // add it
-        return this.AddSpheredLineCrt( startPnt, startColor, endPnt, endColor, lineWidth );
+        return this.AddSpheredLineCrt(startPnt, startColor, endPnt, endColor, lineWidth);
     };
-    this.ChangeLineColor = function (lineID, startColor, endColor) {
+    this.ChangeLineColor = function(lineID, startColor, endColor)
+    {
         lines[lineID].color1 = startColor;
         lines[lineID].color2 = endColor;
     };
-    this.ChangeLineWidth = function (lineID, width) {
+    this.ChangeLineWidth = function(lineID, width)
+    {
         lines[lineID].width = width;
     };
-    this.ChangeLinePositionCrt = function (lineID, startPosition, endPosition) {
+    this.ChangeLinePositionCrt = function(lineID, startPosition, endPosition)
+    {
         lines[lineID].position1 = startPosition;
         lines[lineID].position2 = endPosition;
     };
-    this.ChangeLinePositionSph = function (lineID, startPosition, endPosition, center) {
+    this.ChangeLinePositionSph = function(lineID, startPosition, endPosition, center)
+    {
         var phi1 = startPosition.x;
         var theta1 = startPosition.y;
         var radius1 = startPosition.z;
@@ -157,44 +170,52 @@ function EveCurveLineSet() {
         var theta2 = endPosition.y;
         var radius2 = endPosition.z;
         // is given in spherical coords, so convert them into cartesian
-        var startPnt = [ radius1 * Math.sin( phi1 ) * Math.sin( theta1 ), radius1 * Math.cos( theta1 ), radius1 * Math.cos( phi1 ) * Math.sin( theta1 ) ];
-        var endPnt = [ radius2 * Math.sin( phi2 ) * Math.sin( theta2 ), radius2 * Math.cos( theta2 ), radius2 * Math.cos( phi2 ) * Math.sin( theta2 ) ];
+        var startPnt = [radius1 * Math.sin(phi1) * Math.sin(theta1), radius1 * Math.cos(theta1), radius1 * Math.cos(phi1) * Math.sin(theta1)];
+        var endPnt = [radius2 * Math.sin(phi2) * Math.sin(theta2), radius2 * Math.cos(theta2), radius2 * Math.cos(phi2) * Math.sin(theta2)];
         // dont forget center!
         vec3.add(startPnt, center);
         vec3.add(endPnt, center);
         this.ChangeLinePositionCrt(lineID, startPnt, endPnt);
     };
-    this.ChangeLineIntermediateCrt = function (lineID, intermediatePosition) {
+    this.ChangeLineIntermediateCrt = function(lineID, intermediatePosition)
+    {
         lines[lineID].intermediatePosition = intermediatePosition;
     };
-    this.ChangeLineIntermediateSph = function (lineID, intermediatePosition, center) {
+    this.ChangeLineIntermediateSph = function(lineID, intermediatePosition, center)
+    {
         var phiM = middle.x;
         var thetaM = middle.y;
         var radiusM = middle.z;
-        var middlePnt = [ radiusM * Math.sin( phiM ) * Math.sin( thetaM ), radiusM * Math.cos( thetaM ), radiusM * Math.cos( phiM ) * Math.sin( thetaM ) ];
+        var middlePnt = [radiusM * Math.sin(phiM) * Math.sin(thetaM), radiusM * Math.cos(thetaM), radiusM * Math.cos(phiM) * Math.sin(thetaM)];
         vec3.add(middlePnt, center);
         lines[lineID].intermediatePosition = intermediatePosition;
     };
-    this.ChangeLineMultiColor = function (lineID, color, border) {
+    this.ChangeLineMultiColor = function(lineID, color, border)
+    {
         lines[lineID].multiColor = color;
         lines[lineID].multiColorBorder = border;
     };
-    this.ChangeLineAnimation = function (lineID, color, speed, scale) {
+    this.ChangeLineAnimation = function(lineID, color, speed, scale)
+    {
         lines[lineID].overlayColor = color;
         lines[lineID].animationSpeed = speed;
         lines[lineID].animationScale = scale;
     };
-    this.ChangeLineSegmentation = function (lineID, numOfSegments) {
-        if (lines[lineID].type != LINETYPE_STRAIGHT) {
+    this.ChangeLineSegmentation = function(lineID, numOfSegments)
+    {
+        if (lines[lineID].type != LINETYPE_STRAIGHT)
+        {
             lines[lineID].numOfSegments = numOfSegments;
         }
 
     };
-    this.RemoveLine = function (lineID) {
+    this.RemoveLine = function(lineID)
+    {
         emptyLineID.push(lineID);
         lines[lineID].type = LINETYPE_INVALID;
     };
-    this.ClearLines = function () {
+    this.ClearLines = function()
+    {
         lines = [];
         emptyLineID = [];
     };
@@ -214,17 +235,21 @@ function EveCurveLineSet() {
     declaration.stride = 4 * vertexSize;
     declaration.RebuildHash();
 
-    function lineCount() {
+    function lineCount()
+    {
         var count = 0;
-        for (var i = 0; i < lines.length; ++i) {
-            if (lines[i].type != LINETYPE_INVALID) {
+        for (var i = 0; i < lines.length; ++i)
+        {
+            if (lines[i].type != LINETYPE_INVALID)
+            {
                 count += lines[i].numOfSegments;
             }
         }
         return count;
     }
 
-    function fillColorVertices(lineData, buffer, offset) {
+    function fillColorVertices(lineData, buffer, offset)
+    {
         buffer[offset++] = lineData.multiColor[0];
         buffer[offset++] = lineData.multiColor[1];
         buffer[offset++] = lineData.multiColor[2];
@@ -236,7 +261,8 @@ function EveCurveLineSet() {
         return offset;
     }
 
-    function writeLineVerticesToBuffer(self, position1, color1, length1, position2, color2, length2, lineID, buffer, offset) {
+    function writeLineVerticesToBuffer(self, position1, color1, length1, position2, color2, length2, lineID, buffer, offset)
+    {
         var lineData = lines[lineID];
 
         buffer[offset++] = position1[0];
@@ -362,7 +388,8 @@ function EveCurveLineSet() {
 
     }
 
-    function vec3Hermite(out, v1, t1, v2, t2, s) {
+    function vec3Hermite(out, v1, t1, v2, t2, s)
+    {
         var k3 = 2 * s * s * s - 3 * s * s + 1;
         var k2 = -2 * s * s * s + 3 * s * s;
         var k1 = s * s * s - 2 * s * s + s;
@@ -374,9 +401,11 @@ function EveCurveLineSet() {
         return out;
     }
 
-    this.SubmitChanges = function () {
+    this.SubmitChanges = function()
+    {
         vb = null;
-        if (!lines.length) {
+        if (!lines.length)
+        {
             return;
         }
         vbSize = lineCount();
@@ -397,8 +426,10 @@ function EveCurveLineSet() {
         var pt2 = vec3.create();
         var j, tmp, segmentFactor;
 
-        for (var i = 0; i < lines.length; ++i) {
-            switch (lines[i].type) {
+        for (var i = 0; i < lines.length; ++i)
+        {
+            switch (lines[i].type)
+            {
                 case LINETYPE_INVALID:
                     break;
                 case LINETYPE_STRAIGHT:
@@ -419,7 +450,8 @@ function EveCurveLineSet() {
                     vec3.set(startDir, dir1);
                     quat4.set(lines[i].color1, col1);
 
-                    for (j = 0; j < lines[i].numOfSegments; ++j) {
+                    for (j = 0; j < lines[i].numOfSegments; ++j)
+                    {
                         segmentFactor = (j + 1) / lines[i].numOfSegments;
                         mat4.multiplyVec3(rotationMatrix, dir1, dir2);
                         col2[0] = lines[i].color1[0] * (1 - segmentFactor) + lines[i].color2[0] * segmentFactor;
@@ -451,7 +483,8 @@ function EveCurveLineSet() {
 
                     vec3.set(lines[i].position1, pos1);
                     vec3.set(lines[i].color1, col1);
-                    for (j = 0; j < lines[i].numOfSegments; ++j) {
+                    for (j = 0; j < lines[i].numOfSegments; ++j)
+                    {
                         segmentFactor = (j + 1) / lines[i].numOfSegments;
                         vec3Hermite(pos2, lines[i].position1, tangent1, lines[i].position2, tangent2, segmentFactor);
                         col2[0] = lines[i].color1[0] * (1 - segmentFactor) + lines[i].color2[0] * segmentFactor;
@@ -471,7 +504,8 @@ function EveCurveLineSet() {
             }
         }
 
-        if (vb) {
+        if (vb)
+        {
             device.gl.deleteBuffer(vb);
         }
         vb = device.gl.createBuffer();
@@ -479,11 +513,14 @@ function EveCurveLineSet() {
         device.gl.bufferData(device.gl.ARRAY_BUFFER, data, device.gl.STATIC_DRAW);
         device.gl.bindBuffer(device.gl.ARRAY_BUFFER, null);
     };
-    this.GetBatches = function (mode, accumulator) {
-        if (!this.display || !vb) {
+    this.GetBatches = function(mode, accumulator)
+    {
+        if (!this.display || !vb)
+        {
             return;
         }
-        if (mode == device.RM_TRANSPARENT && !this.additive || mode == device.RM_ADDITIVE && this.additive) {
+        if (mode == device.RM_TRANSPARENT && !this.additive || mode == device.RM_ADDITIVE && this.additive)
+        {
             var batch = new Tw2ForwardingRenderBatch();
             mat4.transpose(transform, perObjectData.perObjectVSData.Get('WorldMat'));
             mat4.transpose(transform, perObjectData.perObjectPSData.Get('WorldMat'));
@@ -493,8 +530,10 @@ function EveCurveLineSet() {
             accumulator.Commit(batch);
         }
     };
-    this.Unload = function () {
-        if (vb) {
+    this.Unload = function()
+    {
+        if (vb)
+        {
             device.gl.deleteBuffer(vb);
             vb = null;
         }
@@ -502,7 +541,8 @@ function EveCurveLineSet() {
     /**
      * @return {boolean}
      */
-    this.Render = function (batch, overrideEffect) {
+    this.Render = function(batch, overrideEffect)
+    {
         var effect = overrideEffect || this.lineEffect;
         var effectRes = effect.GetEffectRes();
         if (!effectRes._isGood)
@@ -513,10 +553,12 @@ function EveCurveLineSet() {
         d.gl.bindBuffer(d.gl.ARRAY_BUFFER, vb);
 
         var passCount = effect.GetPassCount();
-        for (var pass = 0; pass < passCount; ++pass) {
+        for (var pass = 0; pass < passCount; ++pass)
+        {
             effect.ApplyPass(pass);
             var passInput = effect.GetPassInput(pass);
-            if (!declaration.SetDeclaration(passInput, declaration.stride)) {
+            if (!declaration.SetDeclaration(passInput, declaration.stride))
+            {
                 return false;
             }
             d.ApplyShadowState();
@@ -525,9 +567,9 @@ function EveCurveLineSet() {
         return true;
     };
 
-    this.Update = function () {
-    };
-    this.UpdateViewDependentData = function (parentTransform) {
+    this.Update = function() {};
+    this.UpdateViewDependentData = function(parentTransform)
+    {
         mat4.identity(transform);
         mat4.translate(transform, this.translation);
         var rotationTransform = mat4.transpose(quat4.toMat4(this.rotation, mat4.create()));
@@ -537,3 +579,24 @@ function EveCurveLineSet() {
     };
 }
 
+/**
+ * Gets curve line set res objects
+ * @param {Array} [out=[]] - Optional receiving array
+ * @returns {Array.<Tw2EffectRes|Tw2TextureRes>} [out]
+ */
+EveCurveLineSet.prototype.GetResources = function(out)
+{
+    if (out === undefined)
+    {
+        out = [];
+    };
+
+    this.lineEffect.GetResources(out);
+
+    if (this.pickEffect !== null)
+    {
+        this.pickEffect.GetResources(out);
+    }
+
+    return out;
+}

--- a/src/eve/EveEffectRoot.js
+++ b/src/eve/EveEffectRoot.js
@@ -44,6 +44,26 @@ function EveEffectRoot()
 }
 
 /**
+ * Gets effect root res objects
+ * @param {Array} [out=[]] - Optional receiving array
+ * @returns {Array.<Tw2EffectRes|Tw2TextureRes>} [out]
+ */
+EveEffectRoot.prototype.GetResources = function(out)
+{
+    if (out === undefined)
+    {
+        out = [];
+    };
+
+    if (this.highDetail !== null)
+    {
+        this.highDetail.GetResources(out);
+    }
+
+    return out;
+}
+
+/**
  * Internal per frame update
  * @param {number} dt - Delta Time
  */

--- a/src/eve/EveMeshOverlayEffect.js
+++ b/src/eve/EveMeshOverlayEffect.js
@@ -60,3 +60,34 @@ EveMeshOverlayEffect.prototype.GetEffects = function(mode)
         }
     }
 };
+
+/**
+ * Gets Mesh Overlay resource objects
+ * @param {Array} [out=[]] - Optional receiving array
+ * @returns {Array.<Tw2EffectRes|Tw2TextureRes|Tw2GeometryRes>} [out]
+ */
+EveMeshOverlayEffect.prototype.GetResources = function(out)
+{
+    if (out === undefined)
+    {
+        out = [];
+    }
+
+    var self = this;
+
+    function getEffectResources(effectName, out)
+    {
+        for (var i = 0; i < self[effectName].length; i++)
+        {
+            self[effectName].GetResources(out);
+        }
+    }
+
+    getEffectResources('opaqueEffects', out);
+    getEffectResources('decalEffects', out);
+    getEffectResources('transparentEffects', out);
+    getEffectResources('additiveEffects', out);
+    getEffectResources('distortionEffects', out);
+
+    return out;
+}

--- a/src/eve/EvePlaneSet.js
+++ b/src/eve/EvePlaneSet.js
@@ -44,6 +44,26 @@ EvePlaneSet.prototype.Initialize = function()
 };
 
 /**
+ * Gets plane set res objects
+ * @param {Array} [out=[]] - Optional receiving array
+ * @returns {Array} {Array.<Tw2EffectRes|Tw2TextureRes|Tw2GeometryRes>} [out]
+ */
+EvePlaneSet.prototype.GetResources = function(out)
+{
+    if (out === undefined)
+    {
+        out = [];
+    }
+
+    if (this.effect !== null)
+    {
+        this.effect.GetResources(out);
+    }
+
+    return out;
+}
+
+/**
  * Rebuilds the plane set's buffers
  */
 EvePlaneSet.prototype.RebuildBuffers = function()

--- a/src/eve/EvePlanet.js
+++ b/src/eve/EvePlanet.js
@@ -29,6 +29,24 @@ function EvePlanet()
 }
 
 /**
+ * Gets planet res objects
+ * @param {Array} [out=[]] - Optional receiving array
+ * @returns {Array.<Tw2EffectRes|Tw2TextureRes|Tw2GeometryRes>} [out]
+ */
+EvePlanet.prototype.GetResources = function(out)
+{
+    if (out === undefined)
+    {
+        out = [];
+    }
+
+    this.highDetail.GetResources(out);
+    this.effectHeight.GetResources(out);
+
+    return out;
+}
+
+/**
  * Creates the planet
  * @param {number} itemID - the item id is used for randomization
  * @param {string} planetPath - .red file for a planet, or planet template
@@ -247,7 +265,7 @@ EvePlanet.prototype.GetBatches = function(mode, accumulator)
             originalEffect.parameters['HeightMap'].textureRes = this.heightMap.texture;
         }
     }
-    
+
     if (this.display)
     {
         this.highDetail.GetBatches(mode, accumulator);

--- a/src/eve/EveShip.js
+++ b/src/eve/EveShip.js
@@ -70,7 +70,12 @@ EveShip.prototype.GetResources = function(out, excludeChildren)
     }
 
     getSetResources('turretSets', out);
-    getSetResources('boosters', out);
+
+    if (this.boosters !== null)
+    {
+        this.boosters.GetResources(out);
+    }
+
     return out;
 }
 

--- a/src/eve/EveShip.js
+++ b/src/eve/EveShip.js
@@ -16,7 +16,7 @@ function EveShip()
     this.boosters = null;
     this.turretSets = [];
     this._turretSetsLocatorInfo = [];
-    
+
     this.displayTurrets = true;
     this.displayBoosters = true;
 }
@@ -45,6 +45,36 @@ EveShip.prototype.Initialize = function()
 };
 
 /**
+ * Gets ship's res objects
+ * @param {Array} [out=[]] - Optional receiving array
+ * @param {Boolean} excludeChildren - True to exclude children's res objects
+ * @returns {Array.<Tw2EffectRes|Tw2TextureRes|Tw2GeometryRes>} [out]
+ */
+EveShip.prototype.GetResources = function(out, excludeChildren)
+{
+    if (out === undefined)
+    {
+        out = [];
+    };
+
+    this._super.GetResources.call(this, out, excludeChildren);
+
+    var self = this;
+
+    function getSetResources(setName, out)
+    {
+        for (var i = 0; i < self[setName].length; i++)
+        {
+            self[setName][i].GetResources(out);
+        }
+    }
+
+    getSetResources('turretSets', out);
+    getSetResources('boosters', out);
+    return out;
+}
+
+/**
  * Gets render batches
  * @param {RenderMode} mode
  * @param {Tw2BatchAccumulator} accumulator
@@ -57,7 +87,7 @@ EveShip.prototype.GetBatches = function(mode, accumulator)
 
         this._perObjectData.perObjectVSData.Get('Shipdata')[0] = this.boosterGain;
         this._perObjectData.perObjectPSData.Get('Shipdata')[0] = this.boosterGain;
-        
+
         if (this.displayTurrets)
         {
             if (this.lod > 1)
@@ -78,7 +108,7 @@ EveShip.prototype.GetBatches = function(mode, accumulator)
                 }
             }
         }
-        
+
         if (this.boosters && this.displayBoosters)
         {
             this.boosters.GetBatches(mode, accumulator, this._perObjectData);
@@ -102,7 +132,7 @@ EveShip.prototype.Update = function(dt)
         }
         this.boosters.Update(dt, this.transform);
     }
-    
+
     for (var i = 0; i < this.turretSets.length; ++i)
     {
         if (i < this._turretSetsLocatorInfo.length)

--- a/src/eve/EveSpaceObject.js
+++ b/src/eve/EveSpaceObject.js
@@ -70,7 +70,7 @@ function EveSpaceObject()
     this.displayLines = true;
 
     this.displayKillCounterValue = 0;
-    
+
     this._tempVec = vec3.create();
 
     this._perObjectData = new Tw2PerObjectData();
@@ -112,6 +112,60 @@ EveSpaceObject.prototype.Initialize = function()
         }
     }
 };
+
+/**
+ * Gets object's res objects
+ * @param {Array} [out=[]] - Optional receiving array
+ * @param {Boolean} excludeChildren - True to exclude children's res objects
+ * @returns {Array.<Tw2EffectRes|Tw2TextureRes|Tw2GeometryRes>} [out]
+ */
+EveSpaceObject.prototype.GetResources = function(out, excludeChildren)
+{
+    if (out === undefined)
+    {
+        out = [];
+    }
+
+    var self = this;
+
+    if (this.mesh !== null)
+    {
+        this.mesh.GetResources(out);
+    }
+
+    if (this.animation !== null)
+    {
+        this.animation.GetResources(out);
+    }
+
+    function getSetResources(setName, out)
+    {
+        for (var i = 0; i < self[setName].length; i++)
+        {
+            if ('GetResources' in self[setName][i])
+            {
+                self[setName][i].GetResources(out);
+            }
+        }
+    }
+
+    getSetResources('spriteSets', out);
+    getSetResources('turretSets', out);
+    getSetResources('decals', out);
+    getSetResources('spotlightSets', out);
+    getSetResources('planeSets', out);
+    getSetResources('lineSets', out);
+    getSetResources('overlayEffects', out);
+    getSetResources('effectChildren', out);
+
+    if (!excludeChildren)
+    {
+        getSetResources('children', out);
+    }
+
+    return out;
+}
+
 
 /**
  * Resets the lod

--- a/src/eve/EveSpaceObjectDecal.js
+++ b/src/eve/EveSpaceObjectDecal.js
@@ -4,18 +4,18 @@ function EveSpaceObjectDecal()
     this.decalEffect = null;
     this.name = '';
     this.groupIndex = -1;
-    
+
     this.position = vec3.create();
     this.rotation = quat4.create();
     this.scaling = vec3.create();
-    
+
     this.decalMatrix = mat4.create();
     this.invDecalMatrix = mat4.create();
     this.parentGeometry = null;
     this.indexBuffer = [];
     this._indexBuffer = null;
     this.parentBoneIndex = -1;
-    
+
     this._perObjectData = new Tw2PerObjectData();
     this._perObjectData.perObjectVSData = new Tw2RawData();
     this._perObjectData.perObjectVSData.Declare('worldMatrix', 16);
@@ -33,10 +33,10 @@ function EveSpaceObjectDecal()
     mat4.identity(this._perObjectData.perObjectVSData.Get('parentBoneMatrix'));
 
     variableStore.RegisterType('u_DecalMatrix', Tw2MatrixParameter);
-	variableStore.RegisterType('u_InvDecalMatrix', Tw2MatrixParameter);
+    variableStore.RegisterType('u_InvDecalMatrix', Tw2MatrixParameter);
 }
 
-EveSpaceObjectDecal.prototype.Initialize = function ()
+EveSpaceObjectDecal.prototype.Initialize = function()
 {
     var indexes = new Uint16Array(this.indexBuffer);
     this._indexBuffer = device.gl.createBuffer();
@@ -50,12 +50,32 @@ EveSpaceObjectDecal.prototype.Initialize = function ()
     mat4.inverse(this.decalMatrix, this.invDecalMatrix);
 };
 
-EveSpaceObjectDecal.prototype.SetParentGeometry = function (geometryRes)
+/**
+ * Gets decal res objects
+ * @param {Array} [out=[]] - Optional receiving array
+ * @returns {Array.<Tw2EffectRes|Tw2TextureRes|Tw2GeometryRes>} [out]
+ */
+EveSpaceObjectDecal.prototype.GetResources = function(out)
+{
+    if (out === undefined)
+    {
+        out = [];
+    }
+
+    if (this.decalEffect !== null)
+    {
+        this.decalEffect.GetResources(out);
+    }
+
+    return out;
+}
+
+EveSpaceObjectDecal.prototype.SetParentGeometry = function(geometryRes)
 {
     this.parentGeometry = geometryRes;
 };
 
-EveSpaceObjectDecal.prototype.GetBatches = function (mode, accumulator, perObjectData, counter)
+EveSpaceObjectDecal.prototype.GetBatches = function(mode, accumulator, perObjectData, counter)
 {
     if (mode != device.RM_DECAL)
     {
@@ -65,7 +85,8 @@ EveSpaceObjectDecal.prototype.GetBatches = function (mode, accumulator, perObjec
     {
         var batch = new Tw2ForwardingRenderBatch();
         this._perObjectData.perObjectVSData.Set('worldMatrix', perObjectData.perObjectVSData.Get('WorldMat'));
-        if (this.parentBoneIndex >= 0) {
+        if (this.parentBoneIndex >= 0)
+        {
             var bones = perObjectData.perObjectVSData.Get('JointMat');
             var offset = this.parentBoneIndex * 12;
             if (bones[offset + 0] || bones[offset + 4] || bones[offset + 8])
@@ -104,7 +125,7 @@ EveSpaceObjectDecal.prototype.GetBatches = function (mode, accumulator, perObjec
     }
 };
 
-EveSpaceObjectDecal.prototype.Render = function (batch, overrideEffect)
+EveSpaceObjectDecal.prototype.Render = function(batch, overrideEffect)
 {
     var bkIB = this.parentGeometry.meshes[0].indexes;
     var bkStart = this.parentGeometry.meshes[0].areas[0].start;

--- a/src/eve/EveSpotlightSet.js
+++ b/src/eve/EveSpotlightSet.js
@@ -70,6 +70,30 @@ EveSpotlightSet.prototype.Initialize = function()
 };
 
 /**
+ * Gets spotlight set res objects
+ * @param {Array} [out=[]] - Optional receiving array
+ * @returns {Array.<Tw2EffectRes|Tw2TextureRes|Tw2GeometryRes>} [out]
+ */
+EveSpotlightSet.prototype.GetResources = function(out)
+{
+    if (out === undefined)
+    {
+        out = [];
+    }
+
+    if (this.coneEffect !== null)
+    {
+        this.coneEffect.GetResources(out);
+    }
+
+    if (this.glowEffect !== null)
+    {
+        this.glowEffect.GetResources(out);
+    }
+    return out;
+}
+
+/**
  * Rebuilds the spotlight set
  */
 EveSpotlightSet.prototype.RebuildBuffers = function()

--- a/src/eve/EveSpriteSet.js
+++ b/src/eve/EveSpriteSet.js
@@ -58,6 +58,26 @@ EveSpriteSet.prototype.Initialize = function()
 };
 
 /**
+ * Gets Sprite Set Resource Objects
+ * @param {Array} [out=[]] - Optional receiving array
+ * @returns {Array.<Tw2EffectRes|Tw2TextureRes|Tw2GeometryRes>} [out]
+ */
+EveSpriteSet.prototype.GetResources = function(out)
+{
+    if (out === undefined)
+    {
+        out = [];
+    }
+
+    if (this.effect !== null)
+    {
+        this.effect.GetResources(out);
+    }
+
+    return out;
+}
+
+/**
  * Rebuilds the sprite set's buffers
  */
 EveSpriteSet.prototype.RebuildBuffers = function()
@@ -190,7 +210,7 @@ EveSpriteSet.prototype.GetBatches = function(mode, accumulator, perObjectData)
  * @param {Number} warpIntensity
  */
 EveSpriteSet.prototype.GetBoosterGlowBatches = function(mode, accumulator, perObjectData, world, boosterGain,
-                                                        warpIntensity)
+    warpIntensity)
 {
     if (this.display && mode == device.RM_ADDITIVE)
     {

--- a/src/eve/EveStretch.js
+++ b/src/eve/EveStretch.js
@@ -1,4 +1,5 @@
-﻿function EveStretch() {
+function EveStretch()
+{
     this.name = '';
     this.display = true;
     this.update = true;
@@ -23,39 +24,49 @@
 EveStretch._tempVec3 = [vec3.create(), vec3.create(), vec3.create()];
 EveStretch._tempMat4 = [mat4.create(), mat4.create()];
 
-EveStretch.prototype.Update = function (dt) {
-    for (var i = 0; i < this.curveSets.length; ++i) {
+EveStretch.prototype.Update = function(dt)
+{
+    for (var i = 0; i < this.curveSets.length; ++i)
+    {
         this.curveSets[i].Update(dt);
     }
     this._time += dt;
-    if (this.source) {
+    if (this.source)
+    {
         this.source.GetValueAt(this._time, this._sourcePosition);
     }
-    else if (this._useTransformsForStretch) {
+    else if (this._useTransformsForStretch)
+    {
         this._sourcePosition[0] = this._sourceTransform[12];
         this._sourcePosition[1] = this._sourceTransform[13];
         this._sourcePosition[2] = this._sourceTransform[14];
     }
-    if (this.dest) {
+    if (this.dest)
+    {
         this.source.GetValueAt(this._time, this._destinationPosition);
     }
     var directionVec = vec3.subtract(this._destinationPosition, this._sourcePosition, EveStretch._tempVec3[0]);
     var scalingLength = vec3.length(directionVec);
     this.length.value = scalingLength;
     vec3.normalize(directionVec);
-    if (this.sourceObject && this._displaySourceObject) {
+    if (this.sourceObject && this._displaySourceObject)
+    {
         this.sourceObject.Update(dt);
     }
-    if (this.stretchObject) {
+    if (this.stretchObject)
+    {
         this.stretchObject.Update(dt);
     }
-    if (this.destObject && this._displayDestObject) {
+    if (this.destObject && this._displayDestObject)
+    {
         this.destObject.Update(dt);
     }
 }
 
-EveStretch.prototype.UpdateViewDependentData = function () {
-    if (!this.display) {
+EveStretch.prototype.UpdateViewDependentData = function()
+{
+    if (!this.display)
+    {
         return;
     }
     var directionVec = vec3.subtract(this._destinationPosition, this._sourcePosition, EveStretch._tempVec3[0]);
@@ -63,52 +74,80 @@ EveStretch.prototype.UpdateViewDependentData = function () {
     vec3.normalize(directionVec);
 
     var m = EveStretch._tempMat4[0];
-    if (this._useTransformsForStretch) {
+    if (this._useTransformsForStretch)
+    {
         mat4.identity(m);
         mat4.rotateX(m, -Math.PI / 2);
         mat4.multiply(this._sourceTransform, m, m);
     }
-    else {
+    else
+    {
         mat4.identity(m);
         var up = EveStretch._tempVec3[2];
-        if (Math.abs(directionVec[1]) > 0.9) {
+        if (Math.abs(directionVec[1]) > 0.9)
+        {
             up[2] = 1;
         }
-        else {
+        else
+        {
             up[1] = 1;
         }
         var x = vec3.normalize(vec3.cross(up, directionVec, EveStretch._tempVec3[1]));
         vec3.cross(directionVec, x, up);
-        m[0] = x[0]; m[1] = x[1]; m[2] = x[2];
-        m[4] = -directionVec[0]; m[5] = -directionVec[1]; m[6] = -directionVec[2];
-        m[8] = up[0]; m[9] = up[1]; m[10] = up[2];
+        m[0] = x[0];
+        m[1] = x[1];
+        m[2] = x[2];
+        m[4] = -directionVec[0];
+        m[5] = -directionVec[1];
+        m[6] = -directionVec[2];
+        m[8] = up[0];
+        m[9] = up[1];
+        m[10] = up[2];
     }
-    if (this.destObject && this._displayDestObject) {
-        m[12] = this._destinationPosition[0]; m[13] = this._destinationPosition[1]; m[14] = this._destinationPosition[2];
+    if (this.destObject && this._displayDestObject)
+    {
+        m[12] = this._destinationPosition[0];
+        m[13] = this._destinationPosition[1];
+        m[14] = this._destinationPosition[2];
         this.destObject.UpdateViewDependentData(m);
     }
-    if (this.sourceObject && this._displaySourceObject) {
-        if (this._useTransformsForStretch) {
+    if (this.sourceObject && this._displaySourceObject)
+    {
+        if (this._useTransformsForStretch)
+        {
             mat4.identity(m);
             mat4.rotateX(m, -Math.PI / 2);
             mat4.multiply(this._sourceTransform, m, m);
         }
-        else {
-            m[12] = this._sourcePosition[0]; m[13] = this._sourcePosition[1]; m[14] = this._sourcePosition[2];
+        else
+        {
+            m[12] = this._sourcePosition[0];
+            m[13] = this._sourcePosition[1];
+            m[14] = this._sourcePosition[2];
         }
         this.sourceObject.UpdateViewDependentData(m);
     }
-    if (this.stretchObject) {
-        if (this._useTransformsForStretch) {
+    if (this.stretchObject)
+    {
+        if (this._useTransformsForStretch)
+        {
             mat4.identity(m);
             mat4.scale(m, [1, 1, scalingLength]);
             mat4.multiply(this._sourceTransform, m, m);
         }
-        else {
-            m[0] = x[0]; m[1] = x[1]; m[2] = x[2];
-            m[4] = up[0]; m[5] = up[1]; m[6] = up[2];
-            m[8] = -directionVec[0]; m[9] = -directionVec[1]; m[10] = -directionVec[2];
-            if (this._isNegZForward) {
+        else
+        {
+            m[0] = x[0];
+            m[1] = x[1];
+            m[2] = x[2];
+            m[4] = up[0];
+            m[5] = up[1];
+            m[6] = up[2];
+            m[8] = -directionVec[0];
+            m[9] = -directionVec[1];
+            m[10] = -directionVec[2];
+            if (this._isNegZForward)
+            {
                 scalingLength = -scalingLength;
             }
             var s = mat4.scale(mat4.identity(EveStretch._tempMat4[1]), [1, 1, scalingLength]);
@@ -118,35 +157,44 @@ EveStretch.prototype.UpdateViewDependentData = function () {
     }
 }
 
-EveStretch.prototype.GetBatches = function (mode, accumulator, perObjectData) {
-    if (!this.display) {
+EveStretch.prototype.GetBatches = function(mode, accumulator, perObjectData)
+{
+    if (!this.display)
+    {
         return;
     }
-    if (this.sourceObject && this._displaySourceObject) {
+    if (this.sourceObject && this._displaySourceObject)
+    {
         this.sourceObject.GetBatches(mode, accumulator, perObjectData);
     }
-    if (this.destObject && this._displayDestObject) {
+    if (this.destObject && this._displayDestObject)
+    {
         this.destObject.GetBatches(mode, accumulator, perObjectData);
     }
-    if (this.stretchObject) {
+    if (this.stretchObject)
+    {
         this.stretchObject.GetBatches(mode, accumulator, perObjectData);
     }
 };
 
-EveStretch.prototype.SetSourcePosition = function (position) {
+EveStretch.prototype.SetSourcePosition = function(position)
+{
     this._useTransformsForStretch = false;
     this._sourcePosition = position;
 }
 
-EveStretch.prototype.SetDestinationPosition = function (position) {
+EveStretch.prototype.SetDestinationPosition = function(position)
+{
     this._destinationPosition = position;
 }
 
-EveStretch.prototype.SetSourceTransform = function (transform) {
+EveStretch.prototype.SetSourceTransform = function(transform)
+{
     this._useTransformsForStretch = true;
     this._sourceTransform = transform;
 }
 
-EveStretch.prototype.SetIsNegZForward = function (isNegZForward) {
+EveStretch.prototype.SetIsNegZForward = function(isNegZForward)
+{
     this._isNegZForward = isNegZForward;
 }

--- a/src/eve/EveTransform.js
+++ b/src/eve/EveTransform.js
@@ -129,6 +129,35 @@ EveTransform.prototype.Initialize = function()
 };
 
 /**
+ * Gets transform res objects
+ * @param {Array} [out=[]] - Optional receiving array
+ * @param {Boolean} excludeChildren - True to exclude children's res objects
+ * @returns {Array.<Tw2EffectRes|Tw2TextureRes|Tw2GeometryRes>} [out]
+ */
+EveTransform.prototype.GetResources = function(out, excludeChildren)
+{
+    if (out === undefined)
+    {
+        out = [];
+    };
+
+    if (this.mesh !== null)
+    {
+        this.mesh.GetResources(out);
+    }
+
+    if (!excludeChildren)
+    {
+        for (var i = 0; i < this.children; i++)
+        {
+            this.children[i].GetResources(out);
+        }
+    }
+
+    return out;
+}
+
+/**
  * Gets render batches for accumulation
  * @param {RenderMode} mode
  * @param {Tw2BatchAccumulator} accumulator

--- a/src/eve/EveTurretSet.js
+++ b/src/eve/EveTurretSet.js
@@ -56,22 +56,22 @@ function EveTurretSet()
     this.bottomClipHeight = 0;
     this.locatorName = '';
     this.sysBoneHeight = 0;
-    
+
     this.turrets = [];
     this.turretEffect = null;
     this.targetPosition = vec3.create();
     this.firingEffectResPath = '';
     this.firingEffect = null;
-    
+
     this.hasCyclingFiringPos = false;
     this.geometryResPath = '';
     this.geometryResource = null;
 
     this.activeAnimation = new Tw2AnimationController();
     this.inactiveAnimation = new Tw2AnimationController();
-    
+
     this.parentMatrix = mat4.identity(mat4.create());
-    
+
     this.STATE_INACTIVE = 0;
     this.STATE_IDLE = 1;
     this.STATE_FIRING = 2;
@@ -79,7 +79,7 @@ function EveTurretSet()
     this.STATE_UNPACKING = 4;
 
     this.state = this.STATE_IDLE;
-    
+
     this._perObjectDataActive = new Tw2PerObjectData();
     this._perObjectDataActive.perObjectVSData = new Tw2RawData();
     this._perObjectDataActive.perObjectVSData.Declare('baseCutoffData', 4);
@@ -146,6 +146,39 @@ EveTurretSet.prototype.Initialize = function()
         });
     }
 };
+
+/**
+ * Gets turret set res objects
+ * @param {Array} [out=[]] - Optional receiving array
+ * @returns {Array.<Tw2EffectRes|Tw2TextureRes|Tw2GeometryRes>} [out]
+ */
+EveTurretSet.prototype.GetResources = function(out)
+{
+    if (out === undefined)
+    {
+        out = [];
+    }
+
+    if (this.geometryResource !== null)
+    {
+        if (out.indexOf(this.geometryResource) === -1)
+        {
+            out.push(this.geometryResource);
+        }
+    }
+
+    if (this.turretEffect !== null)
+    {
+        this.turretEffect.GetResources(out);
+    }
+
+    if (this.firingEffect !== null)
+    {
+        this.firingEffect.GetResources(out);
+    }
+
+    return out;
+}
 
 /**
  * Rebuilds the turret sets cached data
@@ -576,7 +609,7 @@ EveTurretSet.prototype.EnterStateIdle = function()
 EveTurretSet.prototype.EnterStateFiring = function()
 {
     var self = this;
-    
+
     if (!this.turretEffect || this.state == this.STATE_FIRING)
     {
         this._DoStartFiring();


### PR DESCRIPTION
**GetResources**
- Added `GetResources` method to multiple tw2 and eve constructors.
- These methods gather res objects (`Tw2EffectRes`, `Tw2GeometryRes`, `Tw2TextureRes`) into an array. 
- An optional parameter is available on base object constructors to exclude children from this gathering. (`EveShip`, `EveTransform`, `EveEffectRoot`, `EveSpaceObject`)  
- This method helps a developer to figure out whether a space object is completely built or not (vs. just the red files loaded) and also is useful for some geometry operations on complex objects.

```
/**
 * Gets Res Objects
 * @param {Array} [out=[]] - Optional recieving array
 * @param {Boolean} [ignoreChildren=false] - Option for base objects only
 * @returns {Array.<Tw2GeometryRes|Tw2EffectRes|Tw2TextureRes>} [out]
 */
BaseObject.prototype.GetResources(out, ignoreChildren){ .... }

// example 1
ship.wrappedObjects[0].getResources(ship.wrappedObjects.resources, true)

// example 2
var effectResources = ship.wrappedObjects[0].mesh.opaqueAreas[0].effect.GetResources();
```

**Tw2Resource.js**
- Added 3 Callbacks to the `Tw2Resource` constructor to allow for custom function calls on resource events.

**EveCurveLineSet**
- Rearranged the constructor so that it follows the patterns used else where in the code base
- Refactored all methods into prototypes
- Made enums static constructor values
- Added `disableDepth` which allows a user to ... disable depth calculations
- Fixed incorrect parameter name `center` in one of the prototypes
- Refactored all swizzles to be array indexes (ie. `.x` to `[0]`, `.y` to `[1]`, `.z` to `[2]`)
- Added default line effect parameters
- Added basic documentation
- Beautified