### PR TITLE
Updated Tw2EventEmitter

### DIFF
--- a/src/core/Tw2EventEmitter.js
+++ b/src/core/Tw2EventEmitter.js
@@ -186,7 +186,7 @@ Tw2EventEmitter.RemoveListener = function(emitter, listener)
         {
             if (emitter.__events.hasOwnProperty(eventName))
             {
-                emitter.off(eventName, listener);
+                emitter.__events[eventName].delete(listener)
             }
         }
     }
@@ -209,8 +209,8 @@ Tw2EventEmitter.RemoveEvent = function(emitter, eventName)
         eventName = eventName.toLowerCase();
         if (eventName in emitter.__events)
         {
-            emitter.__events.clear();
-            delete emitter.__events;
+            emitter.__events[eventName].clear();
+            delete emitter.__events[eventName];
             emitter.emit('EventRemoved', eventName);
         }
     }

--- a/src/core/Tw2EventEmitter.js
+++ b/src/core/Tw2EventEmitter.js
@@ -4,6 +4,12 @@
  */
 var Tw2EventEmitter = function()
 {
+    Object.defineProperty(
+        this, '__events',
+        {
+            value: {},
+            writable: false
+        });
     return this;
 };
 

--- a/src/core/Tw2EventEmitter.js
+++ b/src/core/Tw2EventEmitter.js
@@ -1,89 +1,9 @@
 /**
  * Event Emitter
- * @param {String} [name='']
- * @property {String} [name=''] - The name of the emitter
- * @property {{}} events
- * @returns {Tw2EventEmitter}
+ * @returns {*} emitter
  */
-var Tw2EventEmitter = function(name)
+var Tw2EventEmitter = function()
 {
-    this.name = name || '';
-    this.events = {};
-    return this;
-};
-
-/**
- * Gets public only emitter methods (`on`, `off`, `once`, `del`)
- * @param {{}} [out={}] An optional receiving object
- * @returns {{}}
- *
- * @example var public = emitter.GetPublic()
- * // The public object now has the emitter's public functions
- */
-Tw2EventEmitter.prototype.GetPublic = function(out)
-{
-    out || (out = {});
-    this.inherit(out, false);
-    return out;
-};
-
-/**
- * Checks if an event has any listeners
- * @param {String} eventName - The event to check
- * @returns {Boolean}
- *
- * @example emitter.HasListeners('myEvent');
- * // Returns true or false
- */
-Tw2EventEmitter.prototype.HasListeners = function(eventName)
-{
-    if (!(eventName in this.events)) return false;
-    return (this.events[eventName].size !== 0)
-};
-
-/**
- * Registers an Event
- * - Event names are case insensitive
- * - Emits an `EventAdded` event with the event's name as an argument
- * - When using the `on` and `once` methods an event is automatically registered
- * @param  {String} eventName - The event to register
- * @returns {Tw2EventEmitter}
- *
- * @example emitter.register('myEvent');
- * // creates the myEvent event
- * // emits a `EventAdded` event
- */
-Tw2EventEmitter.prototype.register = function(eventName)
-{
-    eventName = eventName.toLowerCase();
-
-    if (!(eventName in this.events))
-    {
-        this.events[eventName] = new Set();
-        this.emit('EventAdded', eventName);
-    }
-    return this;
-};
-
-/**
- * Deregisters an event and removes all listeners
- * - Emits an `EventRemoved` event with the event's name as an argument
- * @param {String} eventName - The event to deregister
- * @returns {Tw2EventEmitter}
- *
- * @example emitter.deregister('myEvent');
- * // Removes all listeners from the event, and then deletes the event
- * // Emits an `EventRemoved` event
- */
-Tw2EventEmitter.prototype.deregister = function(eventName)
-{
-    eventName = eventName.toLowerCase();
-
-    if (eventName in this.events)
-    {
-        this.emit('EventRemoved', eventName);
-        delete this.events[eventName];
-    }
     return this;
 };
 
@@ -91,30 +11,22 @@ Tw2EventEmitter.prototype.deregister = function(eventName)
  * Emits an event
  * @param {String} eventName - The event to emit
  * @param {*} ...args - Any arguments to be passed to the event's listeners
- * @returns {Tw2EventEmitter}
+ * @returns {*} emitter object
  *
  * @example emitter.emit('myEvent', arg1, arg2, arg3);
- * // Emits the 'myEvent' event and calls all of it's listeners with the supplied arguments
+ * // Emits the 'myEvent' event and calls each of it's listeners with the supplied arguments
  */
 Tw2EventEmitter.prototype.emit = function(eventName)
 {
-    eventName = eventName.toLowerCase();
-
-    if (!(eventName in this.events))
-    {
-        return this.register(eventName);
-    }
-
+    eventName = Tw2EventEmitter.Register(this, eventName);
     var args = Array.prototype.slice.call(arguments);
     args.splice(0, 1);
-
-    this.events[eventName].forEach(
+    this.__events[eventName].forEach(
         function(listener)
         {
             listener.apply(undefined, args);
         }
     );
-
     return this;
 };
 
@@ -122,26 +34,24 @@ Tw2EventEmitter.prototype.emit = function(eventName)
  * Adds a listener to an event
  * - A listener can only exist on an Event once unless using the `once` method, self removing listeners are preferred
  * @param {String} eventName - The target event
- * @param {Function} listener - The listener function to add
- * @returns {Tw2EventEmitter}
+ * @param {Function} listener - The listener to add
+ * @returns {*} emitter object
  *
  * @example emitter.on('myEvent', myListener);
  * // Adds `myListener` to the `myEvent` event
  */
 Tw2EventEmitter.prototype.on = function(eventName, listener)
 {
-    eventName = eventName.toLowerCase();
-
-    this.register(eventName);
-    this.events[eventName].add(listener);
+    eventName = Tw2EventEmitter.Register(this, eventName);
+    this.__events[eventName].add(listener);
     return this;
 };
 
 /**
  * Adds a listener to an event and removes it after it's first emit
  * @param {String} eventName - The target event
- * @param {Function} listener - The listener function to add for one emit only
- * @returns {Tw2EventEmitter}
+ * @param {Function} listener - The listener to add for one emit only
+ * @returns {*} emitter object
  *
  * @example emitter.once('myEvent', myListener);
  * // Adds `myListener` to the `myEvent` event
@@ -149,15 +59,13 @@ Tw2EventEmitter.prototype.on = function(eventName, listener)
  */
 Tw2EventEmitter.prototype.once = function(eventName, listener)
 {
+    eventName = Tw2EventEmitter.Register(this, eventName);
     var self = this;
-    eventName = eventName.toLowerCase();
-
     var once = function once()
     {
         listener.apply(undefined, arguments);
         self.off(eventName, once);
     };
-
     this.on(eventName, once);
     return this;
 };
@@ -165,8 +73,8 @@ Tw2EventEmitter.prototype.once = function(eventName, listener)
 /**
  * Removes a listener from an event
  * @param {String} eventName - The target event
- * @param {Function} listener - The listener to remove from an event
- * @returns {Tw2EventEmitter}
+ * @param {Function} listener - The listener to remove
+ * @returns {*} emitter object
  *
  * @example emitter.off('myEvent', myListener);
  * // Removes `myListener` from the `myEvent` event
@@ -174,66 +82,170 @@ Tw2EventEmitter.prototype.once = function(eventName, listener)
 Tw2EventEmitter.prototype.off = function(eventName, listener)
 {
     eventName = eventName.toLowerCase();
-
-    if (eventName in this.events)
+    if ('__events' in this && eventName in this.__events)
     {
-        this.events[eventName].delete(listener)
+        this.__events[eventName].delete(listener)
     }
     return this;
 };
 
 /**
- * Deletes a listener from all of the emitter's events
- * @param {Function} listener - The listener to delete
- * @returns {Tw2EventEmitter}
- *
- * @example emitter.del(myListener);
- * // Removes `myListener` from every emitter event
+ * Internal helper
+ * - Adds the `__event` property to objects that don't already have it (allows for usage of Object.assign)
+ * - Adds an event name to an emitter if it doesn't already exist
+ * - Ensures that eventNames are always lower case
+ * @param {*} emitter - target emitter
+ * @param {String} eventName - event to register
+ * @returns {String} eventName
  */
-Tw2EventEmitter.prototype.del = function(listener)
+Tw2EventEmitter.Register = function(emitter, eventName)
 {
-    const self = this;
-    for (var eventName in this.events)
+    if (!('__events' in emitter))
     {
-        if (this.events.hasOwnProperty(eventName))
+        Object.defineProperty(emitter, '__events',
+            {
+                value: {},
+                writable: false
+            });
+    }
+
+    eventName = eventName.toLowerCase();
+    if (!(eventName in emitter.__events))
+    {
+        emitter.__events[eventName] = new Set();
+        emitter.emit('EventAdded', eventName);
+    }
+    return eventName;
+}
+
+/**
+ * Checks if an emitter's event has any listeners
+ * @param {*} emitter - target emitter
+ * @param {String} eventName - event to check
+ * @returns {Boolean}
+ *
+ * @example Tw2EventEmitter.HasListeners(myEmitter, 'myEvent');
+ * // Returns true or false
+ */
+Tw2EventEmitter.HasListeners = function(emitter, eventName)
+{
+    if (!('__events' in emitter) || !(eventName in emitter.__events))
+    {
+        return false;
+    }
+    return (emitter.__events[eventName].size !== 0)
+};
+
+/**
+ * Gets an array of an emitter's event names that a listener is on
+ * @param {*} emitter - target emitter
+ * @param {Function} listener - listener to check
+ * @returns {Array.<String>}
+ *
+ * @example Tw2EventEmitter.HasListener(myEmitter, myListener)
+ * // returns an array of `myEmitter`'s event names that `myListener` is on
+ */
+Tw2EventEmitter.HasListener = function(emitter, listener)
+{
+    var result = [];
+    if ('__events' in emitter)
+    {
+        for (var eventName in emitter.__events)
         {
-            self.off(eventName, listener);
+            if (emitter.__events.hasOwnProperty(eventName))
+            {
+                if (emitter.__events[eventName].has(listener))
+                {
+                    result.push(eventName);
+                }
+            }
         }
     }
-    return this;
+    return result;
+}
+
+/**
+ * Removes a listener completely from an emitter
+ * @param {*} emitter - target emitter
+ * @param {Function} listener - listener to delete
+ *
+ * @example Tw2EventEmitter.RemoveListener(myEmitter, myListener);
+ * // Removes `myListener` from every event on `myEmitter`
+ */
+Tw2EventEmitter.RemoveListener = function(emitter, listener)
+{
+    if ('__events' in emitter)
+    {
+        for (var eventName in emitter.__events)
+        {
+            if (emitter.__events.hasOwnProperty(eventName))
+            {
+                emitter.off(eventName, listener);
+            }
+        }
+    }
 };
+
+/**
+ * Removes an event from an emitter, and all of it's listeners
+ * @param {*} emitter
+ * @param {String} eventName
+ *
+ * @example Tw2EventEmitter.RemoveEvent(myEmitter, 'myEvent');
+ * // Removes all listeners on `myEvent`
+ * // Deletes the `myEvent` event
+ * // emits `EventRemoved` with the event name as it's argument
+ */
+Tw2EventEmitter.RemoveEvent = function(emitter, eventName)
+{
+    if ('__events' in emitter)
+    {
+        eventName = eventName.toLowerCase();
+        if (eventName in emitter.__events)
+        {
+            emitter.__events.clear();
+            delete emitter.__events;
+            emitter.emit('EventRemoved', eventName);
+        }
+    }
+}
 
 /**
  * Adds bound emitter functions to a target object
- * - No checks are made to see if these methods or property names already exist
- * @param {{}} target - The object inheriting the emitter's functions
+ * - No checks are made to see if these methods or property names already exist in the target object
+ * @param {*} emitter - source emitter
+ * @param {{}} target - target object
  * @param {Boolean} [excludeEmit=false] - Optional control for excluding the `emit` method
- * @return {Tw2EventEmitter}
+ * @return {*}
  *
- * @example emitter.inherit(myObject, true);
+ * @example Tw2EventEmitter.Inherit(myEmitter, myObject, true);
  * // `myObject` now has `on`, `off`, `del` and `log` emitter methods
- * @example emitter.inherit(myObject);
+ * @example Tw2EventEmitter.Inherit(myEmitter, myObject);
  * // `myObject` now has `on`, `off`, `del`, `log` and `emit` emitter methods
  */
-Tw2EventEmitter.prototype.inherit = function(target, excludeEmit)
+Tw2EventEmitter.Inherit = function(emitter, target, excludeEmit)
 {
-    target['on'] = this.on.bind(this);
-    target['off'] = this.off.bind(this);
-    target['del'] = this.del.bind(this);
-    target['log'] = this.log.bind(this);
-
-    if (!excludeEmit)
-    {
-        target['emit'] = this.emit.bind(this);
-    }
-
-    return this;
+    target['on'] = emitter.on.bind(emitter);
+    target['off'] = emitter.off.bind(emitter);
+    target['once'] = emitter.once.bind(emitter);
+    if (!excludeEmit) target['emit'] = this.emit.bind(this);
+    return target;
 };
 
 /**
- * An Emit wrapper that emits an event and also creates a console output from a supplied event data object
- * - The console output replicates the existing ccpwgl console logging
- * - Console output can be toggled globally with { @link<Tw2EventEmitter.consoleErrors> and @link<Tw2EventEmitter.consoleLogs> }
+ * CCPWGL Global emitter
+ * @param {String} name - Console log prefix
+ * @param {Boolean} consoleErrors - Toggle for displaying console error outputs (warn, error)
+ * @param {Boolean} consoleLogs - Toggle for displaying console log outputs (log, info, debug)
+ * @type {Tw2EventEmitter}
+ */
+var emitter = new Tw2EventEmitter();
+emitter.name = 'CCPWGL';
+emitter.consoleErrors = true;
+emitter.consoleLogs = true;
+
+/**
+ * An Emit wrapper for the ccpwgl global emitter which emits an event and also creates a console output from a supplied event data object
  * @param {String}  eventName               - The event to emit
  * @param {{}}      eventData               - event data
  * @param {String} [eventData.msg='']       - event message
@@ -242,10 +254,11 @@ Tw2EventEmitter.prototype.inherit = function(target, excludeEmit)
  * @param {Number} [eventData.time]         - the time it took to process the event path (rounds to 3 decimal places)
  * @param {String} [eventData.type]         - a string representing the unique event type
  * @param {Object} [eventData.data]         - data relevant to the event type
+ * @param {Object} [eventData.err]          - javascript error object
  * @param {Number|String} [eventData.value] - a single value relevant to the event type
  * @param {Array.<String>} [eventData.src]  - an array of the functions involved in the event
  */
-Tw2EventEmitter.prototype.log = function(eventName, eventData)
+emitter.log = function(eventName, eventData)
 {
     var d = eventData;
     if (!d.log) d.log = 'log';
@@ -256,16 +269,16 @@ Tw2EventEmitter.prototype.log = function(eventName, eventData)
     {
         case ('throw'):
             log = 'error';
-            if (!Tw2EventEmitter.consoleErrors) return;
+            if (!this.consoleErrors) return;
             break;
 
         case ('error'):
         case ('warn'):
-            if (!Tw2EventEmitter.consoleErrors) return;
+            if (!this.consoleErrors) return;
             break;
 
         default:
-            if (!Tw2EventEmitter.consoleLogs) return;
+            if (!this.consoleLogs) return;
     }
 
     var header = this.name.concat(': {', eventName, '}');
@@ -285,18 +298,3 @@ Tw2EventEmitter.prototype.log = function(eventName, eventData)
         console[log](header, body);
     }
 };
-
-/**
- * Global toggle to disable `warn`, `error` and `throw` console logging from Emitter `log` calls
- * @type {Boolean}
- */
-Tw2EventEmitter.consoleErrors = true;
-
-/**
- * Global toggle to disable `log`, `info` and `debug` console logging from Emitter `log` calls
- * @type {Boolean}
- */
-Tw2EventEmitter.consoleLogs = true;
-
-
-var emitter = new Tw2EventEmitter('CCPWGL');

--- a/src/core/Tw2EventEmitter.js
+++ b/src/core/Tw2EventEmitter.js
@@ -219,16 +219,16 @@ Tw2EventEmitter.RemoveEvent = function(emitter, eventName)
  * @return {*}
  *
  * @example Tw2EventEmitter.Inherit(myEmitter, myObject, true);
- * // `myObject` now has `on`, `off`, `del` and `log` emitter methods
+ * // `myObject` now has `on`, `off`, and `log` emitter methods
  * @example Tw2EventEmitter.Inherit(myEmitter, myObject);
- * // `myObject` now has `on`, `off`, `del`, `log` and `emit` emitter methods
+ * // `myObject` now has `on`, `off`, `log` and `emit` emitter methods
  */
 Tw2EventEmitter.Inherit = function(emitter, target, excludeEmit)
 {
     target['on'] = emitter.on.bind(emitter);
     target['off'] = emitter.off.bind(emitter);
     target['once'] = emitter.once.bind(emitter);
-    if (!excludeEmit) target['emit'] = this.emit.bind(this);
+    if (!excludeEmit) target['emit'] = emitter.emit.bind(this);
     return target;
 };
 


### PR DESCRIPTION
- Separated the `log` emit wrapper prototype and it's associated properties from the `Tw2EventEmitter` constructor and added them to the global ccpwgl emitter instance only
- Made changes so that `Tw2EventEmitter`'s prototypes could be safely assigned to other objects using `Object.assign` and so that they'd continue to work as expected
- Refactored all of the helper and non-essential prototypes to be static functions. This reduces the chance of overwriting existing methods and minimizes the amount of inherited prototypes when using `Object.assign`
- Changed the `_event` @property to `__event` to minimize the chances of overwriting an existing property when using `Object.assign` and made it "protected" 
- These changes do not effect any current usages of this Constructor in `ccpwgl_int`
- Updated examples

example:
```
Object.assign(EveSpaceObject.prototype, Tw2EventEmitter.prototype);
// All EveSpaceObjects now have `emit`, `on`, `off`, `once` prototypes
```


