### PR TITLE
Updated visibility options for Tw2Mesh, EveMeshOverlayEffect, EveSpaceObject, EveShip

### DIFF
--- a/src/core/Tw2Mesh.js
+++ b/src/core/Tw2Mesh.js
@@ -66,13 +66,15 @@ Tw2MeshLineArea.batchType = Tw2GeometryLineBatch;
  * @property {Array.<Tw2MeshArea>} additiveAreas
  * @property {Array.<Tw2MeshArea>} pickableAreas
  * @property {Array.<Tw2MeshArea>} decalAreas
- * @property {Array.<Tw2MeshArea>} depthAreas
- * @property {boolean} display - enables/disables all render batch accumulations
- * @property {boolean} displayOpaque - enables/disables opaque area batch accumulations
- * @property {boolean} displayTransparent - enables/disables transparent area batch accumulations
- * @property {boolean} displayAdditive - enables/disables additive area batch accumulations
- * @property {boolean} displayPickable - enables/disables pickable area batch accumulations
- * @property {boolean} displayDecal - enables/disables decal area batch accumulations
+ * @property {Array.<Tw2MeshArea>} depthAreas       - Not supported
+ * @property {boolean} display                      - Enables/ disables all mesh batch accumulations
+ * @parameter {{}} visible                          - Batch accumulation options for the mesh's elements
+ * @property {boolean} visible.opaqueAreas          - Enables/ disables opaque area batch accumulation
+ * @property {boolean} visible.transparentAreas     - Enables/ disables transparent area batch accumulation
+ * @property {boolean} visible.additiveAreas        - Enables/ disables additive area batch accumulation
+ * @property {boolean} visible.pickableAreas        - Enables/ disables pickable area batch accumulation
+ * @property {boolean} visible.decalAreas           - Enables/ disables decal area batch accumulation
+ * @property {boolean} visible.depthAreas           - Not supported
  * @constructor
  */
 function Tw2Mesh()
@@ -91,11 +93,13 @@ function Tw2Mesh()
     this.depthAreas = [];
 
     this.display = true;
-    this.displayOpaque = true;
-    this.displayTransparent = true;
-    this.displayAdditive = true;
-    this.displayPickable = true;
-    this.displayDecal = true;
+    this.visible = {};
+    this.visible.opaqueAreas = true;
+    this.visible.transparentAreas = true;
+    this.visible.additiveAreas = true;
+    this.visible.pickableAreas = true;
+    this.visible.decalAreas = true;
+    this.visible.depthAreas = true;
 }
 
 /**
@@ -122,29 +126,24 @@ Tw2Mesh.prototype.GetResources = function(out)
         out = [];
     }
 
-    var self = this;
-
     if (out.indexOf(this.geometryResource) === -1)
     {
         out.push(this.geometryResource);
     }
 
-    function getAreaResources(areaName, out)
+    for (var type in this.visible)
     {
-        for (var i = 0; i < self[areaName].length; i++)
+        if (this.visible.hasOwnProperty(type) && this[type].length)
         {
-            self[areaName][i].effect.GetResources(out);
+            for (var i = 0; i < this[type].length; i++)
+            {
+                this[type][i].effect.GetResources(out);
+            }
         }
     }
 
-    getAreaResources('additiveAreas', out);
-    getAreaResources('decalAreas', out);
-    getAreaResources('depthAreas', out);
-    getAreaResources('opaqueAreas', out);
-    getAreaResources('pickableAreas', out);
-    getAreaResources('transparentAreas', out);
     return out;
-}
+};
 
 /**
  * Gets render batches from a mesh area array and commits them to an accumulator
@@ -193,23 +192,23 @@ Tw2Mesh.prototype.GetBatches = function(mode, accumulator, perObjectData)
     if (this.display)
     {
 
-        if (this.displayOpaque && mode == device.RM_OPAQUE)
+        if (mode == device.RM_OPAQUE && this.visible.opaqueAreas)
         {
             this._GetAreaBatches(this.opaqueAreas, mode, accumulator, perObjectData);
         }
-        else if (this.displayDecal && mode == device.RM_DECAL)
+        else if (mode == device.RM_DECAL && this.visible.decalAreas)
         {
             this._GetAreaBatches(this.decalAreas, mode, accumulator, perObjectData);
         }
-        else if (this.displayTransparent && mode == device.RM_TRANSPARENT)
+        else if (mode == device.RM_TRANSPARENT && this.visible.transparentAreas)
         {
             this._GetAreaBatches(this.transparentAreas, mode, accumulator, perObjectData);
         }
-        else if (this.displayAdditive && mode == device.RM_ADDITIVE)
+        else if (mode == device.RM_ADDITIVE && this.visible.additiveAreas)
         {
             this._GetAreaBatches(this.additiveAreas, mode, accumulator, perObjectData);
         }
-        else if (this.displayPickable && mode == device.RM_PICKABLE)
+        else if (mode == device.RM_PICKABLE && this.visible.pickableAreas)
         {
             this._GetAreaBatches(this.pickableAreas, mode, accumulator, perObjectData);
         }

--- a/src/eve/EveMeshOverlayEffect.js
+++ b/src/eve/EveMeshOverlayEffect.js
@@ -95,7 +95,7 @@ EveMeshOverlayEffect.prototype.GetResources = function(out)
         {
             for (var i = 0; i < this[type].length; i++)
             {
-                this[type].GetResources(out);
+                this[type][i].GetResources(out);
             }
         }
     }

--- a/src/eve/EveMeshOverlayEffect.js
+++ b/src/eve/EveMeshOverlayEffect.js
@@ -1,6 +1,5 @@
 /**
  * Constructor for Overlay Effects
- * @property {boolean} display
  * @property {boolean} update
  * @property {Tw2CurveSet} curveSet
  * @property {string} name
@@ -8,12 +7,18 @@
  * @property {Array.<Tw2Effect>} decalEffects
  * @property {Array.<Tw2Effect>} transparentEffects
  * @property {Array.<Tw2Effect>} additiveEffects
- * @property {Array.<Tw2Effect>} distortionEffects - Currently doesn't work in ccpwgl
+ * @property {Array.<Tw2Effect>} distortionEffects - Currently not supported
+ * @property {boolean} display                     - Enables/ disables all batch accumulations
+ * @property {{}} visible                          - Batch accumulation options for the overlay effect
+ * @property {boolean} visible.opaqueEffects       - Enables/ disables opaque effect batch accumulation
+ * @property {boolean} visible.decalEffects        - Enables/ disables decal effect batch accumulation
+ * @property {boolean} visible.transparentEffects  - Enables/ disables transparent effect batch accumulation
+ * @property {boolean} visible.additiveEffects     - Enables/ disables additive effect batch accumulation
+ * @property {boolean} visible.distortionEffects   - Currently not supported
  * @constructor
  */
 function EveMeshOverlayEffect()
 {
-    this.display = true;
     this.update = true;
     this.curveSet = null;
     this.name = '';
@@ -22,6 +27,14 @@ function EveMeshOverlayEffect()
     this.transparentEffects = [];
     this.additiveEffects = [];
     this.distortionEffects = [];
+
+    this.display = true;
+    this.visible = {};
+    this.visible.opaqueEffects = true;
+    this.visible.decalEffects = true;
+    this.visible.transparentEffects = true;
+    this.visible.additiveEffects = true;
+    this.visible.distortionEffects = false;
 }
 
 /**
@@ -45,18 +58,21 @@ EveMeshOverlayEffect.prototype.GetEffects = function(mode)
 {
     if (this.display)
     {
-        switch (mode)
+        if (mode == device.RM_OPAQUE && this.visible.opaqueEffects)
         {
-            case device.RM_OPAQUE:
-                return this.opaqueEffects;
-            case device.RM_DECAL:
-                return this.decalEffects;
-            case device.RM_TRANSPARENT:
-                return this.transparentEffects;
-            case device.RM_ADDITIVE:
-                return this.additiveEffects;
-            default:
-                return null;
+            return this.opaqueEffects;
+        }
+        else if (mode == device.RM_TRANSPARENT && this.visible.transparentEffects)
+        {
+            return this.transparentEffects;
+        }
+        else if (mode == device.RM_ADDITIVE && this.visible.additiveEffects)
+        {
+            return this.additiveEffects;
+        }
+        else if (mode == device.RM_DECAL && this.visible.decalEffects)
+        {
+            return this.decalEffects;
         }
     }
 };
@@ -73,21 +89,16 @@ EveMeshOverlayEffect.prototype.GetResources = function(out)
         out = [];
     }
 
-    var self = this;
-
-    function getEffectResources(effectName, out)
+    for (var type in this.visible)
     {
-        for (var i = 0; i < self[effectName].length; i++)
+        if (this.visible.hasOwnProperty(type) && this[type].length)
         {
-            self[effectName].GetResources(out);
+            for (var i = 0; i < this[type].length; i++)
+            {
+                this[type].GetResources(out);
+            }
         }
     }
 
-    getEffectResources('opaqueEffects', out);
-    getEffectResources('decalEffects', out);
-    getEffectResources('transparentEffects', out);
-    getEffectResources('additiveEffects', out);
-    getEffectResources('distortionEffects', out);
-
     return out;
-}
+};

--- a/src/eve/EveShip.js
+++ b/src/eve/EveShip.js
@@ -4,8 +4,8 @@
  * @property {Array.<EveBoosterSet>} boosters
  * @property {Array.<EveTurretSet>} turretSets
  * @property {Array} _turretSetsLocatorInfo
- * @property {boolean} displayTurrets - Toggles turret rendering
- * @property {boolean} displayBoosters - Toggles booster rendering
+ * @property {boolean} visible.turretSets      - Enables/ disables turret set batch accumulation
+ * @property {boolean} visible.boosters        - Enables/ disables booster batch accumulation
  * @inherits EveSpaceObject
  * @constructor
  */
@@ -17,8 +17,8 @@ function EveShip()
     this.turretSets = [];
     this._turretSetsLocatorInfo = [];
 
-    this.displayTurrets = true;
-    this.displayBoosters = true;
+    this.visible.turretSets = true;
+    this.visible.boosters = true;
 }
 
 /**
@@ -55,7 +55,7 @@ EveShip.prototype.GetResources = function(out, excludeChildren)
     if (out === undefined)
     {
         out = [];
-    };
+    }
 
     this._super.GetResources.call(this, out, excludeChildren);
 
@@ -77,7 +77,7 @@ EveShip.prototype.GetResources = function(out, excludeChildren)
     }
 
     return out;
-}
+};
 
 /**
  * Gets render batches
@@ -93,7 +93,7 @@ EveShip.prototype.GetBatches = function(mode, accumulator)
         this._perObjectData.perObjectVSData.Get('Shipdata')[0] = this.boosterGain;
         this._perObjectData.perObjectPSData.Get('Shipdata')[0] = this.boosterGain;
 
-        if (this.displayTurrets)
+        if (this.visible.turretSets)
         {
             if (this.lod > 1)
             {
@@ -104,17 +104,17 @@ EveShip.prototype.GetBatches = function(mode, accumulator)
             }
             else
             {
-                for (var i = 0; i < this.turretSets.length; ++i)
+                for (var t = 0; t < this.turretSets.length; ++t)
                 {
-                    if (this.turretSets[i].firingEffect)
+                    if (this.turretSets[t].firingEffect)
                     {
-                        this.turretSets[i].firingEffect.GetBatches(mode, accumulator, this._perObjectData);
+                        this.turretSets[t].firingEffect.GetBatches(mode, accumulator, this._perObjectData);
                     }
                 }
             }
         }
 
-        if (this.boosters && this.displayBoosters)
+        if (this.boosters && this.visible.boosters)
         {
             this.boosters.GetBatches(mode, accumulator, this._perObjectData);
         }
@@ -151,9 +151,10 @@ EveShip.prototype.Update = function(dt)
             }
         }
     }
-    for (var i = 0; i < this.turretSets.length; ++i)
+
+    for (var t = 0; i < this.turretSets.length; ++i)
     {
-        this.turretSets[i].Update(dt, this.transform);
+        this.turretSets[t].Update(dt, this.transform);
     }
 };
 
@@ -167,7 +168,7 @@ EveShip.prototype.UpdateViewDependentData = function()
     {
         this.turretSets[i].UpdateViewDependentData();
     }
-}
+};
 
 /**
  * Rebuilds the ship's booster set


### PR DESCRIPTION
- All sub element display options moved to `this.visible` objects
- Parent `this.display` options left as is for backwards compatibility
- Killmark count and killmark visibility separated
- `EveMeshOverlayEffect` `this.display` property now works
- Individual `EveMeshOverlayEffect` effect rendering can now be toggled on/ off