### PR TITLE
Minor fix Tw2RigidOrientation

### DIFF
--- a/src/curves/Tw2RigidOrientation.js
+++ b/src/curves/Tw2RigidOrientation.js
@@ -75,7 +75,7 @@ Tw2RigidOrientation.prototype.GetValueAt = function(time, value)
 {
     if (this.states.length == 0 || time < 0 || time < this.states[0].time)
     {
-        quat4.set(this.value, value);
+        quat4.set(this.start, value);
         return value;
     }
     var key = 0;


### PR DESCRIPTION
- The `GetValueAt` prototype now returns the start value if there are no keys/ states or the time is less than 0