### PR TITLE
Minor update to Tw2ObjectReader

### DIFF
--- a/src/core/Tw2ObjectReader.js
+++ b/src/core/Tw2ObjectReader.js
@@ -145,13 +145,28 @@ Tw2ObjectReader.prototype._ConstructObject = function (data)
 
         throw new Error('YAML: object with undefined type \"' + data.type + '\"');
     }
+   
     for (var k in data)
     {
         if (data.hasOwnProperty(k) && k != 'type')
         {
-            object[k] = data[k];
+            if (object[k] && data[k].constructor == Object)
+            {
+                for (var key in data[k])
+                {
+                    if (data[k].hasOwnProperty(key))
+                    {
+                        object[k][key] = data[k][key];
+                    }
+                }
+            }
+            else
+            {
+                object[k] = data[k];
+            }
         }
     }
+    
     if ('Initialize' in object)
     {
         object.Initialize();


### PR DESCRIPTION
- When a constructor's property already exists and it is expected to be a plain object, it is no longer overwritten with a plain object when constructed from a `.red` file 
- This allows developers to extend existing Tw2 Constructor's plain objects with their own custom Constructors (The binary loader already allows for this)

example:
![example](https://cloud.githubusercontent.com/assets/7591350/25050712/0b415700-219d-11e7-804a-72e9b0162842.png)
